### PR TITLE
Changed Polygon#+ behavior

### DIFF
--- a/rays/src/polygon.cpp
+++ b/rays/src/polygon.cpp
@@ -1588,7 +1588,10 @@ namespace Rays
 	Polygon
 	operator + (const Polygon& lhs, const Polygon& rhs)
 	{
-		return lhs | rhs;
+		std::vector<Polyline> polylines;
+		for (const auto& polyline : lhs) polylines.emplace_back(polyline);
+		for (const auto& polyline : rhs) polylines.emplace_back(polyline);
+		return Polygon(&polylines[0], polylines.size());
 	}
 
 	Polygon

--- a/rays/test/test_polygon.rb
+++ b/rays/test/test_polygon.rb
@@ -135,6 +135,25 @@ class TestPolygon < Test::Unit::TestCase
     assert_raise(IndexError) {o[-4]}
   end
 
+  def test_add()
+    assert_equal_polygon(
+      polygon(*rect(0, 0, 10, 10).to_a, *rect(5, 0, 10, 10).to_a),
+               rect(0, 0, 10, 10)      + rect(5, 0, 10, 10))
+
+    assert_equal_polygon(
+      polygon(*rect(0, 0, 10, 10).to_a, *rect(5, 0, 10, 10).to_a, *rect(10, 0, 10, 10).to_a),
+               rect(0, 0, 10, 10)     + [rect(5, 0, 10, 10),       rect(10, 0, 10, 10)])
+
+    o = rect(0, 0, 10, 10)
+    assert_equal_polygon(
+      polygon(*rect(0, 0, 10, 10).to_a, *rect(0, 0, 10, 10).to_a),
+      o + o)
+
+    assert_equal_polygon rect(0, 0, 10, 10), rect(0, 0, 10, 10) + polygon()
+    assert_equal_polygon rect(0, 0, 10, 10), polygon() + rect(0, 0, 10, 10)
+    assert_equal_polygon rect(0, 0, 10, 10), rect(0, 0, 10, 10) + []
+  end
+
   def test_sub()
     rect10 = rect 0, 0, 10, 10
 


### PR DESCRIPTION
Previous behavior
"polygonA + polygonB" => polygonA | polygonB

Behavior from now on
"polygonA + polygonB" => Polygon.new(*polygonA.to_a, *polygonB.to_a)