### PR TITLE
xot: Skip linking dependency native extensions to avoid duplicate symbols

### DIFF
--- a/beeps/ext/beeps/extconf.rb
+++ b/beeps/ext/beeps/extconf.rb
@@ -25,7 +25,7 @@ Xot::ExtConf.new Xot, Rucy, Beeps do
       libs       << 'openal'
     end
 
-    $LDFLAGS << ' -Wl,--out-implib=libbeeps.dll.a,--export-all-symbols' if mingw? || cygwin?
+    $LDFLAGS << ' -Wl,--out-implib=libbeeps.dll.a' if mingw? || cygwin?
   end
 
   create_makefile 'beeps_ext'

--- a/beeps/ext/beeps/extconf.rb
+++ b/beeps/ext/beeps/extconf.rb
@@ -25,7 +25,7 @@ Xot::ExtConf.new Xot, Rucy, Beeps do
       libs       << 'openal'
     end
 
-    $LDFLAGS << ' -Wl,--out-implib=beeps_ext.dll.a' if mingw? || cygwin?
+    $LDFLAGS << ' -Wl,--out-implib=libbeeps.dll.a' if mingw? || cygwin?
   end
 
   create_makefile 'beeps_ext'

--- a/beeps/ext/beeps/extconf.rb
+++ b/beeps/ext/beeps/extconf.rb
@@ -25,7 +25,7 @@ Xot::ExtConf.new Xot, Rucy, Beeps do
       libs       << 'openal'
     end
 
-    $LDFLAGS << ' -Wl,--export-all-symbols,--out-implib=libbeeps.dll.a' if mingw? || cygwin?
+    $LDFLAGS << ' -Wl,--out-implib=libbeeps.dll.a' if mingw? || cygwin?
   end
 
   create_makefile 'beeps_ext'

--- a/beeps/ext/beeps/extconf.rb
+++ b/beeps/ext/beeps/extconf.rb
@@ -25,7 +25,7 @@ Xot::ExtConf.new Xot, Rucy, Beeps do
       libs       << 'openal'
     end
 
-    $LDFLAGS << ' -Wl,--out-implib=libbeeps.dll.a' if mingw? || cygwin?
+    $LDFLAGS << ' -Wl,--out-implib=libbeeps.dll.a,--export-all-symbols' if mingw? || cygwin?
   end
 
   create_makefile 'beeps_ext'

--- a/beeps/ext/beeps/extconf.rb
+++ b/beeps/ext/beeps/extconf.rb
@@ -25,7 +25,7 @@ Xot::ExtConf.new Xot, Rucy, Beeps do
       libs       << 'openal'
     end
 
-    $LDFLAGS << ' -Wl,--out-implib=libbeeps.dll.a' if mingw? || cygwin?
+    $LDFLAGS << ' -Wl,--export-all-symbols,--out-implib=libbeeps.dll.a' if mingw? || cygwin?
   end
 
   create_makefile 'beeps_ext'

--- a/beeps/lib/beeps/extension.rb
+++ b/beeps/lib/beeps/extension.rb
@@ -31,6 +31,10 @@ module Beeps
       root_dir 'ext'
     end
 
+    def lib_name()
+      "#{name true}.dll" if /mswin|ming|cygwin/.match? RUBY_PLATFORM
+    end
+
   end# Extension
 
 

--- a/rays-video/ext/rays-video/extconf.rb
+++ b/rays-video/ext/rays-video/extconf.rb
@@ -14,10 +14,9 @@ require 'rays-video/extension'
 Xot::ExtConf.new Xot, Rucy, Beeps, Rays, RaysVideo do
   setup do
     headers    << 'ruby.h'
-    libs.unshift 'gdi32', 'opengl32', 'glew32' if win32?
-    frameworks << 'AppKit' << 'AVFoundation'   if osx?
-
-    $LDFLAGS << ' -Wl,--out-implib=librays-video.dll.a,--export-all-symbols' if mingw? || cygwin?
+    libs.unshift 'gdi32', 'opengl32', 'glew32'            if win32?
+    frameworks << 'AppKit' << 'AVFoundation'              if osx?
+    $LDFLAGS   << ' -Wl,--out-implib=librays-video.dll.a' if mingw? || cygwin?
   end
 
   create_makefile 'rays_video_ext'

--- a/rays-video/ext/rays-video/extconf.rb
+++ b/rays-video/ext/rays-video/extconf.rb
@@ -14,14 +14,9 @@ require 'rays-video/extension'
 Xot::ExtConf.new Xot, Rucy, Beeps, Rays, RaysVideo do
   setup do
     headers    << 'ruby.h'
-    libs.unshift 'gdi32', 'opengl32', 'glew32'           if win32?
-    frameworks << 'AppKit' << 'AVFoundation'             if osx?
-    $LDFLAGS << ' -Wl,--out-implib=rays_video_ext.dll.a' if mingw? || cygwin?
-
-    unless osx? || linux?
-      lib_dirs << Rays::Extension.ext_dir
-      libs     << 'rays_ext'
-    end
+    libs.unshift 'gdi32', 'opengl32', 'glew32'          if win32?
+    frameworks << 'AppKit' << 'AVFoundation'            if osx?
+    $LDFLAGS << ' -Wl,--out-implib=librays-video.dll.a' if mingw? || cygwin?
   end
 
   create_makefile 'rays_video_ext'

--- a/rays-video/ext/rays-video/extconf.rb
+++ b/rays-video/ext/rays-video/extconf.rb
@@ -14,9 +14,9 @@ require 'rays-video/extension'
 Xot::ExtConf.new Xot, Rucy, Beeps, Rays, RaysVideo do
   setup do
     headers    << 'ruby.h'
-    libs.unshift 'gdi32', 'opengl32', 'glew32'            if win32?
-    frameworks << 'AppKit' << 'AVFoundation'              if osx?
-    $LDFLAGS   << ' -Wl,--out-implib=librays-video.dll.a' if mingw? || cygwin?
+    libs.unshift 'gdi32', 'opengl32', 'glew32' if win32?
+    frameworks << 'AppKit' << 'AVFoundation'   if osx?
+    $LDFLAGS   << ' -Wl,--export-all-symbols,--out-implib=librays-video.dll.a' if mingw? || cygwin?
   end
 
   create_makefile 'rays_video_ext'

--- a/rays-video/ext/rays-video/extconf.rb
+++ b/rays-video/ext/rays-video/extconf.rb
@@ -14,8 +14,8 @@ require 'rays-video/extension'
 Xot::ExtConf.new Xot, Rucy, Beeps, Rays, RaysVideo do
   setup do
     headers    << 'ruby.h'
-    libs.unshift 'gdi32', 'opengl32', 'glew32' if win32?
-    frameworks << 'AppKit' << 'AVFoundation'   if osx?
+    libs.unshift 'gdi32', 'opengl32', 'glew32'            if win32?
+    frameworks << 'AppKit' << 'AVFoundation'              if osx?
     $LDFLAGS   << ' -Wl,--out-implib=librays-video.dll.a' if mingw? || cygwin?
   end
 

--- a/rays-video/ext/rays-video/extconf.rb
+++ b/rays-video/ext/rays-video/extconf.rb
@@ -14,9 +14,10 @@ require 'rays-video/extension'
 Xot::ExtConf.new Xot, Rucy, Beeps, Rays, RaysVideo do
   setup do
     headers    << 'ruby.h'
-    libs.unshift 'gdi32', 'opengl32', 'glew32'          if win32?
-    frameworks << 'AppKit' << 'AVFoundation'            if osx?
-    $LDFLAGS << ' -Wl,--out-implib=librays-video.dll.a' if mingw? || cygwin?
+    libs.unshift 'gdi32', 'opengl32', 'glew32' if win32?
+    frameworks << 'AppKit' << 'AVFoundation'   if osx?
+
+    $LDFLAGS << ' -Wl,--out-implib=librays-video.dll.a,--export-all-symbols' if mingw? || cygwin?
   end
 
   create_makefile 'rays_video_ext'

--- a/rays-video/ext/rays-video/extconf.rb
+++ b/rays-video/ext/rays-video/extconf.rb
@@ -16,7 +16,7 @@ Xot::ExtConf.new Xot, Rucy, Beeps, Rays, RaysVideo do
     headers    << 'ruby.h'
     libs.unshift 'gdi32', 'opengl32', 'glew32' if win32?
     frameworks << 'AppKit' << 'AVFoundation'   if osx?
-    $LDFLAGS   << ' -Wl,--export-all-symbols,--out-implib=librays-video.dll.a' if mingw? || cygwin?
+    $LDFLAGS   << ' -Wl,--out-implib=librays-video.dll.a' if mingw? || cygwin?
   end
 
   create_makefile 'rays_video_ext'

--- a/rays-video/lib/rays-video/extension.rb
+++ b/rays-video/lib/rays-video/extension.rb
@@ -31,6 +31,10 @@ module RaysVideo
       root_dir 'ext'
     end
 
+    def lib_name()
+      "#{name true}.dll" if /mswin|ming|cygwin/.match? RUBY_PLATFORM
+    end
+
   end# Extension
 
 

--- a/rays/ext/rays/extconf.rb
+++ b/rays/ext/rays/extconf.rb
@@ -16,8 +16,8 @@ Xot::ExtConf.new Xot, Rucy, Rays do
     libs.unshift 'SDL2', 'GLEW', 'GL'                    if linux?
     frameworks << 'AppKit' << 'OpenGL' << 'AVFoundation' if osx?
 
-    $CPPFLAGS << ' -DRAYS_32BIT_PIXELS_STRING'      if RUBY_PLATFORM == 'x64-mingw-ucrt'
-    $LDFLAGS  << ' -Wl,--out-implib=rays_ext.dll.a' if mingw? || cygwin?
+    $CPPFLAGS << ' -DRAYS_32BIT_PIXELS_STRING'     if RUBY_PLATFORM == 'x64-mingw-ucrt'
+    $LDFLAGS  << ' -Wl,--out-implib=librays.dll.a' if mingw? || cygwin?
   end
 
   create_makefile 'rays_ext'

--- a/rays/ext/rays/extconf.rb
+++ b/rays/ext/rays/extconf.rb
@@ -16,8 +16,7 @@ Xot::ExtConf.new Xot, Rucy, Rays do
     libs.unshift 'SDL2', 'GLEW', 'GL'                    if linux?
     frameworks << 'AppKit' << 'OpenGL' << 'AVFoundation' if osx?
     $CPPFLAGS << ' -DRAYS_32BIT_PIXELS_STRING'           if RUBY_PLATFORM == 'x64-mingw-ucrt'
-
-    $LDFLAGS  << ' -Wl,--out-implib=librays.dll.a,--export-all-symbols' if mingw? || cygwin?
+    $LDFLAGS  << ' -Wl,--out-implib=librays.dll.a'       if mingw? || cygwin?
   end
 
   create_makefile 'rays_ext'

--- a/rays/ext/rays/extconf.rb
+++ b/rays/ext/rays/extconf.rb
@@ -16,7 +16,7 @@ Xot::ExtConf.new Xot, Rucy, Rays do
     libs.unshift 'SDL2', 'GLEW', 'GL'                    if linux?
     frameworks << 'AppKit' << 'OpenGL' << 'AVFoundation' if osx?
     $CPPFLAGS << ' -DRAYS_32BIT_PIXELS_STRING'           if RUBY_PLATFORM == 'x64-mingw-ucrt'
-    $LDFLAGS  << ' -Wl,--out-implib=librays.dll.a' if mingw? || cygwin?
+    $LDFLAGS  << ' -Wl,--out-implib=librays.dll.a'       if mingw? || cygwin?
   end
 
   create_makefile 'rays_ext'

--- a/rays/ext/rays/extconf.rb
+++ b/rays/ext/rays/extconf.rb
@@ -15,9 +15,9 @@ Xot::ExtConf.new Xot, Rucy, Rays do
     libs.unshift 'gdi32', 'opengl32', 'glew32'           if win32?
     libs.unshift 'SDL2', 'GLEW', 'GL'                    if linux?
     frameworks << 'AppKit' << 'OpenGL' << 'AVFoundation' if osx?
+    $CPPFLAGS << ' -DRAYS_32BIT_PIXELS_STRING'           if RUBY_PLATFORM == 'x64-mingw-ucrt'
 
-    $CPPFLAGS << ' -DRAYS_32BIT_PIXELS_STRING'     if RUBY_PLATFORM == 'x64-mingw-ucrt'
-    $LDFLAGS  << ' -Wl,--out-implib=librays.dll.a' if mingw? || cygwin?
+    $LDFLAGS  << ' -Wl,--out-implib=librays.dll.a,--export-all-symbols' if mingw? || cygwin?
   end
 
   create_makefile 'rays_ext'

--- a/rays/ext/rays/extconf.rb
+++ b/rays/ext/rays/extconf.rb
@@ -16,7 +16,7 @@ Xot::ExtConf.new Xot, Rucy, Rays do
     libs.unshift 'SDL2', 'GLEW', 'GL'                    if linux?
     frameworks << 'AppKit' << 'OpenGL' << 'AVFoundation' if osx?
     $CPPFLAGS << ' -DRAYS_32BIT_PIXELS_STRING'           if RUBY_PLATFORM == 'x64-mingw-ucrt'
-    $LDFLAGS  << ' -Wl,--out-implib=librays.dll.a'       if mingw? || cygwin?
+    $LDFLAGS  << ' -Wl,--export-all-symbols,--out-implib=librays.dll.a' if mingw? || cygwin?
   end
 
   create_makefile 'rays_ext'

--- a/rays/ext/rays/extconf.rb
+++ b/rays/ext/rays/extconf.rb
@@ -16,7 +16,7 @@ Xot::ExtConf.new Xot, Rucy, Rays do
     libs.unshift 'SDL2', 'GLEW', 'GL'                    if linux?
     frameworks << 'AppKit' << 'OpenGL' << 'AVFoundation' if osx?
     $CPPFLAGS << ' -DRAYS_32BIT_PIXELS_STRING'           if RUBY_PLATFORM == 'x64-mingw-ucrt'
-    $LDFLAGS  << ' -Wl,--export-all-symbols,--out-implib=librays.dll.a' if mingw? || cygwin?
+    $LDFLAGS  << ' -Wl,--out-implib=librays.dll.a' if mingw? || cygwin?
   end
 
   create_makefile 'rays_ext'

--- a/rays/lib/rays/extension.rb
+++ b/rays/lib/rays/extension.rb
@@ -31,6 +31,10 @@ module Rays
       root_dir 'ext'
     end
 
+    def lib_name()
+      "#{name true}.dll" if /mswin|ming|cygwin/.match? RUBY_PLATFORM
+    end
+
   end# Extension
 
 

--- a/reflex/ext/reflex/extconf.rb
+++ b/reflex/ext/reflex/extconf.rb
@@ -15,12 +15,7 @@ Xot::ExtConf.new Xot, Rucy, Rays, Reflex do
     headers    << 'ruby.h'
     libs.unshift 'gdi32', 'winmm', 'opengl32', 'glew32', 'xinput' if win32?
     frameworks << 'Cocoa' << 'GameController'                     if osx?
-    $LDFLAGS   << ' -Wl,--out-implib=reflex_ext.dll.a'            if mingw? || cygwin?
-
-    unless osx? || linux?
-      lib_dirs << Rays::Extension.ext_dir
-      libs     << 'rays_ext'
-    end
+    $LDFLAGS   << ' -Wl,--out-implib=libreflex.dll.a'             if mingw? || cygwin?
   end
 
   create_makefile 'reflex_ext'

--- a/reflex/ext/reflex/extconf.rb
+++ b/reflex/ext/reflex/extconf.rb
@@ -15,7 +15,8 @@ Xot::ExtConf.new Xot, Rucy, Rays, Reflex do
     headers    << 'ruby.h'
     libs.unshift 'gdi32', 'winmm', 'opengl32', 'glew32', 'xinput' if win32?
     frameworks << 'Cocoa' << 'GameController'                     if osx?
-    $LDFLAGS   << ' -Wl,--out-implib=libreflex.dll.a'             if mingw? || cygwin?
+
+    $LDFLAGS << ' -Wl,--out-implib=libreflex.dll.a,--export-all-symbols' if mingw? || cygwin?
   end
 
   create_makefile 'reflex_ext'

--- a/reflex/ext/reflex/extconf.rb
+++ b/reflex/ext/reflex/extconf.rb
@@ -15,7 +15,7 @@ Xot::ExtConf.new Xot, Rucy, Rays, Reflex do
     headers    << 'ruby.h'
     libs.unshift 'gdi32', 'winmm', 'opengl32', 'glew32', 'xinput' if win32?
     frameworks << 'Cocoa' << 'GameController'                     if osx?
-    $LDFLAGS << ' -Wl,--out-implib=libreflex.dll.a'               if mingw? || cygwin?
+    $LDFLAGS << ' -Wl,--export-all-symbols,--out-implib=libreflex.dll.a' if mingw? || cygwin?
   end
 
   create_makefile 'reflex_ext'

--- a/reflex/ext/reflex/extconf.rb
+++ b/reflex/ext/reflex/extconf.rb
@@ -15,8 +15,7 @@ Xot::ExtConf.new Xot, Rucy, Rays, Reflex do
     headers    << 'ruby.h'
     libs.unshift 'gdi32', 'winmm', 'opengl32', 'glew32', 'xinput' if win32?
     frameworks << 'Cocoa' << 'GameController'                     if osx?
-
-    $LDFLAGS << ' -Wl,--out-implib=libreflex.dll.a,--export-all-symbols' if mingw? || cygwin?
+    $LDFLAGS << ' -Wl,--out-implib=libreflex.dll.a'               if mingw? || cygwin?
   end
 
   create_makefile 'reflex_ext'

--- a/reflex/ext/reflex/extconf.rb
+++ b/reflex/ext/reflex/extconf.rb
@@ -15,7 +15,7 @@ Xot::ExtConf.new Xot, Rucy, Rays, Reflex do
     headers    << 'ruby.h'
     libs.unshift 'gdi32', 'winmm', 'opengl32', 'glew32', 'xinput' if win32?
     frameworks << 'Cocoa' << 'GameController'                     if osx?
-    $LDFLAGS << ' -Wl,--export-all-symbols,--out-implib=libreflex.dll.a' if mingw? || cygwin?
+    $LDFLAGS << ' -Wl,--out-implib=libreflex.dll.a' if mingw? || cygwin?
   end
 
   create_makefile 'reflex_ext'

--- a/reflex/ext/reflex/extconf.rb
+++ b/reflex/ext/reflex/extconf.rb
@@ -15,7 +15,7 @@ Xot::ExtConf.new Xot, Rucy, Rays, Reflex do
     headers    << 'ruby.h'
     libs.unshift 'gdi32', 'winmm', 'opengl32', 'glew32', 'xinput' if win32?
     frameworks << 'Cocoa' << 'GameController'                     if osx?
-    $LDFLAGS << ' -Wl,--out-implib=libreflex.dll.a' if mingw? || cygwin?
+    $LDFLAGS   << ' -Wl,--out-implib=libreflex.dll.a'             if mingw? || cygwin?
   end
 
   create_makefile 'reflex_ext'

--- a/reflex/lib/reflex/extension.rb
+++ b/reflex/lib/reflex/extension.rb
@@ -31,6 +31,10 @@ module Reflex
       root_dir 'ext'
     end
 
+    def lib_name()
+      "#{name true}.dll" if /mswin|ming|cygwin/.match? RUBY_PLATFORM
+    end
+
   end# Extension
 
 

--- a/rucy/lib/rucy/extension.rb
+++ b/rucy/lib/rucy/extension.rb
@@ -31,6 +31,10 @@ module Rucy
       root_dir 'ext'
     end
 
+    def lib_name()
+      name true
+    end
+
   end# Extension
 
 

--- a/xot/lib/xot/extconf.rb
+++ b/xot/lib/xot/extconf.rb
@@ -11,13 +11,17 @@ module Xot
     include Xot::Rake
     include Xot::Util
 
-    attr_reader :extensions, :defs, :inc_dirs, :lib_dirs, :headers, :libs, :local_libs, :frameworks
-
     def initialize(*extensions, &block)
       @extensions = extensions.map {|x| x.const_get :Extension}
       @defs, @inc_dirs, @lib_dirs, @headers, @libs, @local_libs, @frameworks =
         ([[]] * 7).map(&:dup)
       Xot::BlockUtil.instance_eval_or_block_call self, &block if block
+    end
+
+    attr_reader :extensions, :defs, :inc_dirs, :lib_dirs, :headers, :libs, :local_libs, :frameworks
+
+    def my_ext()
+      extensions.last
     end
 
     def debug()
@@ -29,7 +33,7 @@ module Xot
 
       extensions.each do |ext|
         name     = ext.name true
-        lib_name = ext == extensions.last ? name : ext.lib_name
+        lib_name = ext == my_ext ? name : ext.lib_name
         headers << "#{name}.h"
         local_libs << lib_name if lib_name
       end
@@ -61,13 +65,15 @@ module Xot
       super
 
       if mingw? || cygwin?
-        own_lib = extensions.last.name(true)
+        name = my_ext.name true
+        opts = %w[
+          -Wl,--export-all-symbols,--whole-archive
+          -l#{name}
+          -Wl,--no-whole-archive
+        ].join ' '
         filter_file('Makefile') {|s|
-          s.sub!(/^DEFFILE\s*=.*$/, 'DEFFILE =')
-          s.sub!(" -l#{own_lib}") {
-            " -Wl,--export-all-symbols,--whole-archive -l#{own_lib} -Wl,--no-whole-archive"
-          }
-          s
+          s.sub(/^DEFFILE\s*=.*$/, 'DEFFILE =')
+           .sub(/^(LOCAL_LIBS\s*=.*) -l#{name}\b/) {"#{$1} #{opts}"}
         }
       end
     end

--- a/xot/lib/xot/extconf.rb
+++ b/xot/lib/xot/extconf.rb
@@ -59,6 +59,8 @@ module Xot
       exit 1 unless libs.all?    {|s| have_library s, 't'}
 
       super
+
+      filter_file('Makefile') {_1.sub /^DEFFILE\s*=.*$/, 'DEFFILE ='} if mingw? || cygwin?
     end
 
   end# ExtConf

--- a/xot/lib/xot/extconf.rb
+++ b/xot/lib/xot/extconf.rb
@@ -47,14 +47,7 @@ module Xot
       $CFLAGS   = make_cflags   $CFLAGS   + ' -x c++'
       $CXXFLAGS = make_cflags   $CXXFLAGS + ' -x c++' if $CXXFLAGS
       $LDFLAGS  = make_ldflags  ldflags, lib_dirs, frameworks
-      libs_str = local_libs.reverse.map {|s| " -l#{s}"}.join
-      if mingw? || cygwin?
-        own_lib = extensions.last.name(true)
-        libs_str.sub!(" -l#{own_lib}") {
-          " -Wl,--whole-archive -l#{own_lib} -Wl,--no-whole-archive"
-        }
-      end
-      $LOCAL_LIBS << libs_str
+      $LOCAL_LIBS << local_libs.reverse.map {|s| " -l#{s}"}.join
     end
 
     def create_makefile(*args)
@@ -67,7 +60,16 @@ module Xot
 
       super
 
-      filter_file('Makefile') {_1.sub /^DEFFILE\s*=.*$/, 'DEFFILE ='} if mingw? || cygwin?
+      if mingw? || cygwin?
+        own_lib = extensions.last.name(true)
+        filter_file('Makefile') {|s|
+          s.sub!(/^DEFFILE\s*=.*$/, 'DEFFILE =')
+          s.sub!(" -l#{own_lib}") {
+            " -Wl,--whole-archive -l#{own_lib} -Wl,--no-whole-archive"
+          }
+          s
+        }
+      end
     end
 
   end# ExtConf

--- a/xot/lib/xot/extconf.rb
+++ b/xot/lib/xot/extconf.rb
@@ -30,7 +30,7 @@ module Xot
       extensions.each do |ext|
         name = ext.name(true)
         headers    << "#{name}.h"
-        local_libs << name
+        local_libs << name if ext == extensions.last || !native?(ext)
       end
 
       ldflags = $LDFLAGS.dup
@@ -58,6 +58,13 @@ module Xot
       exit 1 unless libs.all?    {|s| have_library s, 't'}
 
       super
+    end
+
+    private
+
+    def native?(ext)
+      name = ext.name(true)
+      File.exist? File.join(ext.lib_dir, name, 'ext.rb')
     end
 
   end# ExtConf

--- a/xot/lib/xot/extconf.rb
+++ b/xot/lib/xot/extconf.rb
@@ -65,7 +65,7 @@ module Xot
         filter_file('Makefile') {|s|
           s.sub!(/^DEFFILE\s*=.*$/, 'DEFFILE =')
           s.sub!(" -l#{own_lib}") {
-            " -Wl,--whole-archive -l#{own_lib} -Wl,--no-whole-archive"
+            " -Wl,--export-all-symbols,--whole-archive -l#{own_lib} -Wl,--no-whole-archive"
           }
           s
         }

--- a/xot/lib/xot/extconf.rb
+++ b/xot/lib/xot/extconf.rb
@@ -66,7 +66,7 @@ module Xot
 
       if mingw? || cygwin?
         name = my_ext.name true
-        opts = %w[
+        opts = %W[
           -Wl,--export-all-symbols,--whole-archive
           -l#{name}
           -Wl,--no-whole-archive

--- a/xot/lib/xot/extconf.rb
+++ b/xot/lib/xot/extconf.rb
@@ -28,9 +28,10 @@ module Xot
       yield if block_given?
 
       extensions.each do |ext|
-        name = ext.name(true)
-        headers    << "#{name}.h"
-        local_libs << name if ext == extensions.last || !native?(ext)
+        name     = ext.name true
+        lib_name = ext == extensions.last ? name : ext.lib_name
+        headers << "#{name}.h"
+        local_libs << lib_name if lib_name
       end
 
       ldflags = $LDFLAGS.dup
@@ -58,13 +59,6 @@ module Xot
       exit 1 unless libs.all?    {|s| have_library s, 't'}
 
       super
-    end
-
-    private
-
-    def native?(ext)
-      name = ext.name(true)
-      File.exist? File.join(ext.lib_dir, name, 'ext.rb')
     end
 
   end# ExtConf

--- a/xot/lib/xot/extconf.rb
+++ b/xot/lib/xot/extconf.rb
@@ -47,7 +47,14 @@ module Xot
       $CFLAGS   = make_cflags   $CFLAGS   + ' -x c++'
       $CXXFLAGS = make_cflags   $CXXFLAGS + ' -x c++' if $CXXFLAGS
       $LDFLAGS  = make_ldflags  ldflags, lib_dirs, frameworks
-      $LOCAL_LIBS << local_libs.reverse.map {|s| " -l#{s}"}.join
+      libs_str = local_libs.reverse.map {|s| " -l#{s}"}.join
+      if mingw? || cygwin?
+        own_lib = extensions.last.name(true)
+        libs_str.sub!(" -l#{own_lib}") {
+          " -Wl,--whole-archive -l#{own_lib} -Wl,--no-whole-archive"
+        }
+      end
+      $LOCAL_LIBS << libs_str
     end
 
     def create_makefile(*args)

--- a/xot/lib/xot/extension.rb
+++ b/xot/lib/xot/extension.rb
@@ -31,6 +31,10 @@ module Xot
       root_dir 'ext'
     end
 
+    def lib_name()
+      name true
+    end
+
   end# Extension
 
 

--- a/xot/lib/xot/rake.rb
+++ b/xot/lib/xot/rake.rb
@@ -126,7 +126,7 @@ module Xot
         desc "build #{libout}"
         file libout => extout do
           libdir = File.dirname libout
-          libimp = extout.sub(/\.#{dlext}$/, '.dll.a')
+          libimp = File.join File.dirname(extout), "lib#{target_name}.dll.a"
           sh %( cp #{extout} #{libdir} )
           sh %( cp #{libimp} #{libdir} ) if mingw? || cygwin?
         end

--- a/xot/lib/xot/rake.rb
+++ b/xot/lib/xot/rake.rb
@@ -128,11 +128,7 @@ module Xot
           libdir = File.dirname libout
           libimp = File.join File.dirname(extout), "lib#{target_name}.dll.a"
           sh %( cp #{extout} #{libdir} )
-          if mingw? || cygwin?
-            sh %( cp #{libimp} #{libdir} )
-            sh %( nm #{libimp} | wc -l )
-            sh %( nm #{libimp} | grep -i "T " | head -20 )
-          end
+          sh %( cp #{libimp} #{libdir} ) if mingw? || cygwin?
         end
 
         desc "build #{extout}"

--- a/xot/lib/xot/rake.rb
+++ b/xot/lib/xot/rake.rb
@@ -128,7 +128,10 @@ module Xot
           libdir = File.dirname libout
           libimp = File.join File.dirname(extout), "lib#{target_name}.dll.a"
           sh %( cp #{extout} #{libdir} )
-          sh %( cp #{libimp} #{libdir} ) if mingw? || cygwin?
+          if mingw? || cygwin?
+            sh %( cp #{libimp} #{libdir} )
+            sh %( nm #{libimp} | head -50 )
+          end
         end
 
         desc "build #{extout}"

--- a/xot/lib/xot/rake.rb
+++ b/xot/lib/xot/rake.rb
@@ -139,7 +139,6 @@ module Xot
 
         desc "create #{makefile}"
         file makefile => [extconf, depend] + libs do
-          sh %( echo ";" > #{ext_dir}/#{dlname}.def ) if mingw? || cygwin?
           sh %( cd #{ext_dir} && ruby #{File.basename extconf} )
         end
 

--- a/xot/lib/xot/rake.rb
+++ b/xot/lib/xot/rake.rb
@@ -139,6 +139,7 @@ module Xot
 
         desc "create #{makefile}"
         file makefile => [extconf, depend] + libs do
+          sh %( echo EXPORTS > #{ext_dir}/#{dlname}.def ) if mingw? || cygwin?
           sh %( cd #{ext_dir} && ruby #{File.basename extconf} )
         end
 

--- a/xot/lib/xot/rake.rb
+++ b/xot/lib/xot/rake.rb
@@ -139,7 +139,7 @@ module Xot
 
         desc "create #{makefile}"
         file makefile => [extconf, depend] + libs do
-          sh %( echo EXPORTS > #{ext_dir}/#{dlname}.def ) if mingw? || cygwin?
+          sh %( touch #{ext_dir}/#{dlname}.def ) if mingw? || cygwin?
           sh %( cd #{ext_dir} && ruby #{File.basename extconf} )
         end
 

--- a/xot/lib/xot/rake.rb
+++ b/xot/lib/xot/rake.rb
@@ -130,7 +130,8 @@ module Xot
           sh %( cp #{extout} #{libdir} )
           if mingw? || cygwin?
             sh %( cp #{libimp} #{libdir} )
-            sh %( nm #{libimp} | head -50 )
+            sh %( nm #{libimp} | wc -l )
+            sh %( nm #{libimp} | grep -i "T " | head -20 )
           end
         end
 

--- a/xot/lib/xot/rake.rb
+++ b/xot/lib/xot/rake.rb
@@ -139,7 +139,7 @@ module Xot
 
         desc "create #{makefile}"
         file makefile => [extconf, depend] + libs do
-          sh %( touch #{ext_dir}/#{dlname}.def ) if mingw? || cygwin?
+          sh %( echo ";" > #{ext_dir}/#{dlname}.def ) if mingw? || cygwin?
           sh %( cd #{ext_dir} && ruby #{File.basename extconf} )
         end
 


### PR DESCRIPTION
## Summary

- When multiple Ruby extension bundles statically link the same `.a` library, global state (e.g. static variables) gets duplicated across bundles. This causes issues like Sound players registered in one bundle being invisible to `process_streams()` called from another.
- Native extensions (those with `lib/{name}/ext.rb`) are already loaded at runtime, so their symbols can be resolved via dynamic lookup instead of static linking.
- Non-native dependencies (xot, rucy) and the extension's own library are still linked as before.

## Platform-specific behavior

### macOS / Linux
`-Wl,-undefined,dynamic_lookup` allows unresolved symbols to be resolved at runtime. Dependency extensions are simply skipped at link time.

### Windows (MinGW)
All symbols must be resolved at link time. To avoid duplicating static libraries across DLLs while still resolving symbols, the following approach is used:

1. **`--whole-archive`** — Forces all symbols from the extension's own static library into the DLL (not just those referenced by .o files)
2. **`--export-all-symbols`** — Overrides MinGW's behavior where `__declspec(dllexport)` (used by `RUCY_EXPORT`, `RAYS_EXPORT`, etc.) disables auto-export, ensuring all symbols appear in the import library
3. **`DEFFILE` clearing** — Removes mkmf-generated .def file that would restrict exports to just `Init_*`

These flags are injected via Makefile post-processing (not `$LOCAL_LIBS`) to avoid breaking mkmf's `have_header` / `have_library` checks.

Downstream extensions link against the import library (`.dll.a`) via `lib_name` returning `"#{name}.dll"` on Windows.

## Test plan

- [x] macOS: `rake clean ext && rake test` — all modules pass
- [x] Windows CI: verify tests pass
- [x] Ubuntu CI: verify tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)