### PR TITLE
Add audio track support to Video

### DIFF
--- a/beeps/include/beeps/signals.h
+++ b/beeps/include/beeps/signals.h
@@ -19,9 +19,23 @@ namespace Beeps
 
 			Signals ();
 
+			Signals (uint capacity, uint nchannels = 1, double sample_rate = 0);
+
+			Signals (
+				const float* const* channels, uint nsamples, uint nchannels,
+				double sample_rate = 0, uint capacity = 0);
+
 			~Signals ();
 
 			Signals dup () const;
+
+			void clear (uint capacity = 0);
+
+			uint append (
+				const float* const* channels, uint nsamples, uint nchannels,
+				double sample_rate = 0);
+
+			uint append (const Signals& source, uint source_offset = 0);
 
 			double sample_rate () const;
 

--- a/beeps/src/analyser.cpp
+++ b/beeps/src/analyser.cpp
@@ -55,7 +55,7 @@ namespace Beeps
 
 			clear();
 
-			signals   = Signals_create(std::min(size, (uint) Beeps::sample_rate()));
+			signals   = Signals(std::min(size, (uint) Beeps::sample_rate()));
 			pffft     .reset(pffft_new_setup(size, PFFFT_REAL));
 			fft_buffer.reset((float*) pffft_aligned_malloc(sizeof(float) * size));
 			fft_size  = size;
@@ -206,7 +206,7 @@ namespace Beeps
 			return;
 
 		if (nsamples > signals->nsamples())
-			return Signals_clear(signals);
+			return signals->clear();
 
 		Sample* from         = Signals_at(signals, nsamples);
 		Sample* to           = Signals_at(signals, 0);
@@ -244,7 +244,7 @@ namespace Beeps
 		auto& my = self->signals;
 
 		if (my.nchannels() != in.nchannels() || my.sample_rate() != in.sample_rate())
-			my = Signals_create(my.capacity(), in.nchannels(), in.sample_rate());
+			my = Signals(my.capacity(), in.nchannels(), in.sample_rate());
 
 		uint total_nsamples = my.nsamples() + in.nsamples();
 		if (total_nsamples > my.capacity())

--- a/beeps/src/envelope.cpp
+++ b/beeps/src/envelope.cpp
@@ -261,12 +261,9 @@ namespace Beeps
 		Super::filter(context, signals, offset);
 
 		if (!self->adsr_signals)
-		{
-			self->adsr_signals =
-				Signals_create(signals->nsamples(), 1, signals->sample_rate());
-		}
+			self->adsr_signals = Signals(signals->nsamples(), 1, signals->sample_rate());
 		else
-			Signals_clear(&self->adsr_signals, signals->nsamples());
+			self->adsr_signals.clear(signals->nsamples());
 
 		process_envelope_signals(this, &self->adsr_signals);
 		if (self->adsr_signals.nsamples() < signals->nsamples())

--- a/beeps/src/file_in.cpp
+++ b/beeps/src/file_in.cpp
@@ -93,7 +93,7 @@ namespace Beeps
 	{
 		Super::generate(context, signals, offset);
 
-		*offset += Signals_copy(signals, self->signals, *offset);
+		*offset += signals->append(self->signals, *offset);
 	}
 
 

--- a/beeps/src/mixer.cpp
+++ b/beeps/src/mixer.cpp
@@ -113,9 +113,9 @@ namespace Beeps
 
 		auto& insig = self->input_signals;
 		if (!insig)
-			insig = Signals_create(signals->capacity(), signals->nchannels());
+			insig = Signals(signals->capacity(), signals->nchannels());
 		else
-			Signals_clear(&insig, signals->capacity());
+			insig.clear(signals->capacity());
 
 		Processor_get_context(context)->process(input, &insig, &offset);
 
@@ -129,7 +129,7 @@ namespace Beeps
 	Mixer::filter (Context* context, Signals* signals, uint* offset)
 	{
 		Signals_fill(signals, signals->capacity(), 0);
-		Signals_clear(signals);
+		signals->clear();
 
 		Super::filter(context, signals, offset);
 

--- a/beeps/src/osx/signals.mm
+++ b/beeps/src/osx/signals.mm
@@ -41,7 +41,7 @@ namespace Beeps
 		if (!channels)
 			beeps_error(__FILE__, __LINE__, "failed to get channel data");
 
-		return Signals_create(
+		return Signals(
 			channels, nsamples, nchannels, (uint) buffer.format.sampleRate, capacity);
 	}
 

--- a/beeps/src/osx/text_in.mm
+++ b/beeps/src/osx/text_in.mm
@@ -116,7 +116,7 @@ namespace Beeps
 					self->signals.sample_rate());
 			}
 
-			uint copied_size = Signals_copy(signals, self->signals);
+			uint copied_size = signals->append(self->signals);
 			Signals_shift(&self->signals, copied_size);
 			*offset += copied_size;
 		}

--- a/beeps/src/processor.cpp
+++ b/beeps/src/processor.cpp
@@ -284,7 +284,7 @@ namespace Beeps
 	SignalsBuffer::SignalsBuffer (
 		uint nsamples_per_block, uint nchannels, double sample_rate)
 	{
-		buffer = Signals_create(nsamples_per_block, nchannels, sample_rate);
+		buffer = Signals(nsamples_per_block, nchannels, sample_rate);
 		assert(*this);
 	}
 
@@ -307,7 +307,7 @@ namespace Beeps
 
 		while (true)
 		{
-			*offset += Signals_copy(signals, buffer, *offset - buffer_offset);
+			*offset += signals->append(buffer, *offset - buffer_offset);
 
 			bool signals_full = signals->nsamples() == signals->capacity();
 			bool  buffer_full =   buffer.nsamples() ==   buffer.capacity();
@@ -333,7 +333,7 @@ namespace Beeps
 	SignalsBuffer::buffer_next (
 		ProcessorContext* context, Processor* processor, uint offset)
 	{
-		Signals_clear(&buffer);
+		buffer.clear();
 		buffer_offset = offset;
 		context->process(processor, &buffer, &offset, true);
 
@@ -343,7 +343,7 @@ namespace Beeps
 	void
 	SignalsBuffer::clear ()
 	{
-		Signals_clear(&buffer);
+		buffer.clear();
 		buffer_offset = 0;
 	}
 
@@ -359,8 +359,8 @@ namespace Beeps
 	{
 		assert(processor);
 
-		if (!signal) signal = Signals_create(nsamples, 1, sample_rate);
-		Signals_clear(&signal, nsamples);
+		if (!signal) signal = Signals(nsamples, 1, sample_rate);
+		signal.clear(nsamples);
 
 		SignalsBuffer* buffer = NULL;
 		uint offset_          = offset;
@@ -417,7 +417,7 @@ namespace Beeps
 	StreamContext::StreamContext (
 		uint nsamples_per_process, uint nchannels, double sample_rate)
 	:	context(nchannels, sample_rate),
-		signals(Signals_create(nsamples_per_process, nchannels, sample_rate)),
+		signals(nsamples_per_process, nchannels, sample_rate),
 		nsamples_per_process(nsamples_per_process)
 	{
 	}
@@ -427,7 +427,7 @@ namespace Beeps
 	{
 		assert(processor);
 
-		Signals_clear(&signals, nsamples_per_process);
+		signals.clear(nsamples_per_process);
 		context.process(processor, &signals, &offset);
 
 		if (signals.nsamples() < nsamples_per_process)

--- a/beeps/src/reverb.cpp
+++ b/beeps/src/reverb.cpp
@@ -105,9 +105,8 @@ namespace Beeps
 		self->freeverb.setRoomSize( self->room_size);
 		self->freeverb.setDamping(  self->damping);
 
-		uint nchannels   = signals->nchannels();
-		Signals filtered = Signals_create(
-			signals->nsamples(), nchannels, signals->sample_rate());
+		uint nchannels = signals->nchannels();
+		Signals filtered(signals->nsamples(), nchannels, signals->sample_rate());
 
 		Signals_tick(
 			&filtered, *signals,

--- a/beeps/src/sequencer.cpp
+++ b/beeps/src/sequencer.cpp
@@ -139,9 +139,9 @@ namespace Beeps
 		auto& signals = *psignals;
 		Signals_fill(&signals, signals.capacity(), 0);
 
-		uint generate_begin  = *offset;
-		uint generate_end    = *offset + signals.capacity();
-		Signals note_signals = Signals_create(
+		uint generate_begin = *offset;
+		uint generate_end   = *offset + signals.capacity();
+		Signals note_signals(
 			signals.capacity(), signals.nchannels(), signals.sample_rate());
 
 		uint nsamples = 0;
@@ -161,7 +161,7 @@ namespace Beeps
 			assert(begin != end);
 
 			uint note_offset = begin - note_begin;
-			Signals_clear(&note_signals, end - begin);
+			note_signals.clear(end - begin);
 			context.process(note.processor.get(), &note_signals, &note_offset);
 
 			uint mix_offset  = begin - generate_begin;

--- a/beeps/src/signals.cpp
+++ b/beeps/src/signals.cpp
@@ -104,37 +104,6 @@ namespace Beeps
 	};// Signals::Data
 
 
-	Signals
-	Signals_create (uint capacity, uint nchannels, double sample_rate)
-	{
-		Signals s;
-		s.self->frames.reset(
-			new Frames(capacity * nchannels, nchannels, sample_rate));
-		return s;
-	}
-
-	Signals
-	Signals_create (
-		const float* const* channels,
-		uint nsamples, uint nchannels, double sample_rate, uint capacity)
-	{
-		if (!channels)
-			argument_error(__FILE__, __LINE__);
-
-		Signals s = Signals_create(
-			capacity > nsamples ? capacity : nsamples, nchannels, sample_rate);
-
-		for (uint channel = 0; channel < nchannels; ++channel)
-		{
-			Sample* p = Signals_at(&s, 0, channel);
-			for (uint i = 0; i < nsamples; ++i, p += nchannels)
-				*p = channels[channel][i];
-		}
-
-		s.self->nsamples = nsamples;
-		return s;
-	}
-
 	uint
 	Signals_tick (Signals* signals, std::function<void(stk::StkFrames*)> fun)
 	{
@@ -160,7 +129,7 @@ namespace Beeps
 		if (!input)
 			argument_error(__FILE__, __LINE__);
 
-		Signals_clear(output, input.nsamples());
+		output->clear(input.nsamples());
 		Signals_set_nsamples(output, output->capacity());
 
 		fun(output->self->frames.get(), *input.self->frames);
@@ -187,29 +156,6 @@ namespace Beeps
 		signals->self->frames->unslice();
 		Signals_set_nsamples(signals, end);
 		return end;
-	}
-
-	void
-	Signals_clear (Signals* signals)
-	{
-		if (!signals)
-			argument_error(__FILE__, __LINE__);
-
-		signals->self->nsamples = 0;
-	}
-
-	void
-	Signals_clear (Signals* signals, uint capacity)
-	{
-		if (!signals)
-			argument_error(__FILE__, __LINE__);
-		if (!*signals)
-			argument_error(__FILE__, __LINE__);
-		if (capacity <= 0)
-			argument_error(__FILE__, __LINE__);
-
-		Signals_clear(signals);
-		signals->self->frames->resize(capacity, signals->nchannels());
 	}
 
 	void
@@ -254,109 +200,6 @@ namespace Beeps
 			*to++ = *from++;
 
 		Signals_set_nsamples(signals, new_nsamples);
-	}
-
-	static uint
-	copy_samples (Signals* to, const Signals& from, uint from_offset)
-	{
-		assert(to && *to && from);
-
-		if (from_offset >= from.nsamples())
-			return 0;
-
-		uint   to_nchannels = to->nchannels();
-		uint from_nchannels = from.nchannels();
-		uint   to_offset    = to->nsamples();
-		uint   to_nsamples  = to->capacity() - to_offset;
-		uint from_nsamples  = from.nsamples();
-		uint copy_nsamples  =
-			std::min(from_offset + to_nsamples, from_nsamples) - from_offset;
-
-		for (uint channel = 0; channel < to_nchannels; ++channel)
-		{
-			uint from_channel    = channel < from_nchannels ? channel : 0;
-			      Sample*   to_p = Signals_at(to,     to_offset,      channel);
-			const Sample* from_p = Signals_at(from, from_offset, from_channel);
-			for (uint i = 0; i < copy_nsamples; ++i)
-			{
-				 *to_p  = *from_p;
-				  to_p +=    to_nchannels;
-				from_p +=  from_nchannels;
-			}
-		}
-
-		Signals_set_nsamples(to, to->self->nsamples + copy_nsamples);
-		return copy_nsamples;
-	}
-
-	static uint
-	resample (Signals* to, const Signals& from, uint from_offset)
-	{
-		assert(to && *to && from);
-
-		if (from_offset >= from.nsamples())
-			return 0;
-
-		uint    to_offset     = to->nsamples();
-		float          to_sec = (to->capacity() - to_offset) /  to->sample_rate();
-		float from_offset_sec = from_offset                  / from.sample_rate();
-		float        from_sec = from.nsamples()              / from.sample_rate();
-
-		float copy_seconds =
-			std::min(from_offset_sec + to_sec, from_sec) - from_offset_sec;
-
-		uint to_nsamples = 0, from_nsamples = 0;
-		if (from_offset_sec + to_sec <= from_sec)
-		{
-			  to_nsamples = to->capacity() - to->nsamples();
-			from_nsamples = copy_seconds * from.sample_rate();
-		}
-		else
-		{
-			to_nsamples = copy_seconds * to->sample_rate();
-			from_nsamples = from.nsamples() - from_offset;
-		}
-
-		r8b::CDSPResampler24 resampler(
-			from.sample_rate(), to->sample_rate(), from_nsamples);
-		r8b::CFixedBuffer<double> from_buf(from_nsamples), to_buf(to_nsamples);
-
-		for (uint channel = 0; channel < to->nchannels(); ++channel)
-		{
-			uint from_channel = channel < from.nchannels() ? channel : 0;
-
-			for (uint i = 0; i < from_nsamples; ++i)
-				from_buf[i] = *Signals_at(from, from_offset + i, from_channel);
-
-			resampler.clear();
-			resampler.oneshot(
-				(const double*) from_buf, from_nsamples,
-				      (double*)   to_buf,   to_nsamples);
-
-			for (uint i = 0; i < to_nsamples; ++i)
-				*Signals_at(to, to_offset + i, channel) = to_buf[i];
-		}
-
-		Signals_set_nsamples(to, to->self->nsamples + to_nsamples);
-		return from_nsamples;
-	}
-
-	uint
-	Signals_copy (Signals* to, const Signals& from, uint from_offset)
-	{
-		if (!to)
-			argument_error(__FILE__, __LINE__);
-		if (!*to)
-			argument_error(__FILE__, __LINE__);
-		if (!from)
-			argument_error(__FILE__, __LINE__);
-
-		Signals_clear(to);
-
-		if (to->sample_rate() == from.sample_rate())
-			return copy_samples(to, from, from_offset);
-		else
-			return resample(to, from, from_offset);
 	}
 
 	void
@@ -592,8 +435,182 @@ namespace Beeps
 	{
 	}
 
+	Signals::Signals (uint capacity, uint nchannels, double sample_rate)
+	{
+		self->frames.reset(
+			new Frames(capacity * nchannels, nchannels, sample_rate));
+	}
+
+	Signals::Signals (
+		const float* const* channels,
+		uint nsamples, uint nchannels, double sample_rate, uint capacity)
+	{
+		if (!channels)
+			argument_error(__FILE__, __LINE__);
+
+		self->frames.reset(new Frames(
+			std::max(capacity, nsamples) * nchannels, nchannels, sample_rate));
+
+		for (uint channel = 0; channel < nchannels; ++channel)
+		{
+			Sample* p = Signals_at(this, 0, channel);
+			for (uint i = 0; i < nsamples; ++i, p += nchannels)
+				*p = channels[channel][i];
+		}
+
+		self->nsamples = nsamples;
+	}
+
 	Signals::~Signals ()
 	{
+	}
+
+	void
+	Signals::clear (uint capacity)
+	{
+		if (!*this)
+			argument_error(__FILE__, __LINE__);
+
+		self->nsamples = 0;
+		if (capacity > 0)
+			self->frames->resize(capacity, nchannels());
+	}
+
+	template <typename T>
+	static uint
+	copy_samples (
+		Signals* to,
+		const T* const* from_channels, uint from_nsamples, uint from_nchannels,
+		uint from_offset, uint from_stride)
+	{
+		assert(to && *to && from_channels);
+
+		if (from_offset >= from_nsamples)
+			return 0;
+
+		uint to_nchannels = to->nchannels();
+		uint to_offset    = to->nsamples();
+		uint to_nsamples  = to->capacity() - to_offset;
+		uint copy_nsamples =
+			std::min(from_offset + to_nsamples, from_nsamples) - from_offset;
+
+		for (uint ch = 0; ch < to_nchannels; ++ch)
+		{
+			uint from_channel = ch < from_nchannels ? ch : 0;
+			Sample*      to_p = Signals_at(to, to_offset, ch);
+			const T*   from_p = from_channels[from_channel] + from_offset * from_stride;
+			for (uint i = 0; i < copy_nsamples; ++i)
+			{
+				 *to_p  = *from_p;
+				  to_p += to_nchannels;
+				from_p += from_stride;
+			}
+		}
+
+		Signals_set_nsamples(to, to->self->nsamples + copy_nsamples);
+		return copy_nsamples;
+	}
+
+	template <typename T>
+	static uint
+	resample (
+		Signals* to,
+		const T* const* from_channels, uint from_nsamples, uint from_nchannels,
+		double from_sample_rate, uint from_offset, uint from_stride)
+	{
+		assert(to && *to && from_channels);
+
+		if (from_offset >= from_nsamples)
+			return 0;
+
+		uint    to_offset     = to->nsamples();
+		float          to_sec = (to->capacity() - to_offset) /  to->sample_rate();
+		float from_offset_sec = from_offset                  / from_sample_rate;
+		float        from_sec = from_nsamples                / from_sample_rate;
+		float copy_seconds    =
+			std::min(from_offset_sec + to_sec, from_sec) - from_offset_sec;
+
+		uint to_nsamples = 0, copy_nsamples = 0;
+		if (from_offset_sec + to_sec <= from_sec)
+		{
+			  to_nsamples = to->capacity() - to->nsamples();
+			copy_nsamples = copy_seconds * from_sample_rate;
+		}
+		else
+		{
+			  to_nsamples = copy_seconds * to->sample_rate();
+			copy_nsamples = from_nsamples - from_offset;
+		}
+
+		r8b::CDSPResampler24 resampler(
+			from_sample_rate, to->sample_rate(), copy_nsamples);
+		r8b::CFixedBuffer<double> from_buf(copy_nsamples), to_buf(to_nsamples);
+
+		for (uint ch = 0; ch < to->nchannels(); ++ch)
+		{
+			uint from_ch  = ch < from_nchannels ? ch : 0;
+			const T* base = from_channels[from_ch] + from_offset * from_stride;
+
+			for (uint i = 0; i < copy_nsamples; ++i)
+				from_buf[i] = base[i * from_stride];
+
+			resampler.clear();
+			resampler.oneshot(
+				(const double*) from_buf, copy_nsamples,
+				      (double*)   to_buf,   to_nsamples);
+
+			for (uint i = 0; i < to_nsamples; ++i)
+				*Signals_at(to, to_offset + i, ch) = to_buf[i];
+		}
+
+		Signals_set_nsamples(to, to->self->nsamples + to_nsamples);
+		return copy_nsamples;
+	}
+
+	uint
+	Signals::append (
+		const float* const* channels,
+		uint nsamples, uint nchannels, double sample_rate)
+	{
+		if (!*this)
+			argument_error(__FILE__, __LINE__);
+		if (!channels)
+			argument_error(__FILE__, __LINE__);
+
+		if (sample_rate == 0)
+			sample_rate = this->sample_rate();
+
+		if (sample_rate == this->sample_rate())
+			return copy_samples(this, channels, nsamples, nchannels, 0, 1);
+		else
+			return resample(this, channels, nsamples, nchannels, sample_rate, 0, 1);
+	}
+
+	uint
+	Signals::append (const Signals& source, uint source_offset)
+	{
+		if (!*this)
+			argument_error(__FILE__, __LINE__);
+		if (!source)
+			argument_error(__FILE__, __LINE__);
+
+		uint nchannels = source.nchannels();
+		std::vector<const Sample*> channels(nchannels);
+		for (uint ch = 0; ch < nchannels; ++ch)
+			channels[ch] = Signals_at(source, 0, ch);
+
+		if (sample_rate() == source.sample_rate())
+		{
+			return copy_samples(
+				this, channels.data(), source.nsamples(), nchannels,
+				source_offset, nchannels);
+		}
+		else
+		{
+			return resample(
+				this, channels.data(), source.nsamples(), nchannels, source.sample_rate(),
+				source_offset, nchannels);
+		}
 	}
 
 	Signals

--- a/beeps/src/signals.h
+++ b/beeps/src/signals.h
@@ -21,13 +21,6 @@ namespace Beeps
 	template <typename T> class SignalSamples;
 
 
-	Signals Signals_create (
-		uint capacity, uint nchannels = 1, double sample_rate = 0);
-
-	Signals Signals_create (
-		const float* const* channels,
-		uint nsamples, uint nchannels, double sample_rate = 0, uint capacity = 0);
-
 	uint Signals_tick (
 		Signals* signals,
 		std::function<void(stk::StkFrames*)> fun);
@@ -40,17 +33,11 @@ namespace Beeps
 		Signals* signals, uint start, uint length,
 		std::function<void(stk::StkFrames*)> fun);
 
-	void Signals_clear (Signals* signals);
-
-	void Signals_clear (Signals* signals, uint capacity);
-
 	void Signals_fill (
 		Signals* signals, uint nsamples, Sample value,
 		uint offset = 0);
 
 	void Signals_shift (Signals* signals, uint nsamples);
-
-	uint Signals_copy (Signals* to, const Signals& from, uint from_offset = 0);
 
 	void Signals_add (     Signals* signals, const Signals& add);
 

--- a/beeps/src/sound.cpp
+++ b/beeps/src/sound.cpp
@@ -522,7 +522,23 @@ namespace Beeps
 				}
 
 				source.queue(buffer);
-				if (source.state() == STOPPED) source.play();
+				if (source.state() == STOPPED)
+				{
+					expand_buffer();
+					source.play();
+				}
+			}
+		}
+
+		void expand_buffer ()
+		{
+			if (buffers.size() >= 10) return;
+
+			SoundBuffer extra(true);
+			if (process_stream(&extra))
+			{
+				source.queue(extra);
+				buffers.emplace_back(extra);
 			}
 		}
 

--- a/beeps/src/time_stretch.cpp
+++ b/beeps/src/time_stretch.cpp
@@ -66,8 +66,8 @@ namespace Beeps
 		if (self->scale == 1)
 			return Super::filter(context, signals, offset);
 
-		uint nsamples  = signals->capacity();
-		Signals source = Signals_create(
+		uint nsamples = signals->capacity();
+		Signals source(
 			nsamples / self->scale, signals->nchannels(), signals->sample_rate());
 
 		Super::filter(context, &source, offset);

--- a/beeps/src/win32/signals.cpp
+++ b/beeps/src/win32/signals.cpp
@@ -150,10 +150,10 @@ namespace Beeps
 		if (bytes.empty())
 			beeps_error(__FILE__, __LINE__, "failed to read bytes: '%s'", path);
 
-		uint Bps        = format.wBitsPerSample / 8;
-		uint nchannels  = format.nChannels;
-		uint nsamples   = bytes.size() / Bps / nchannels;
-		Signals signals = Signals_create(nsamples, nchannels, format.nSamplesPerSec);
+		uint Bps       = format.wBitsPerSample / 8;
+		uint nchannels = format.nChannels;
+		uint nsamples  = bytes.size() / Bps / nchannels;
+		Signals signals(nsamples, nchannels, format.nSamplesPerSec);
 
 		for (uint channel = 0; channel < nchannels; ++channel)
 		{

--- a/beeps/src/x_pass.h
+++ b/beeps/src/x_pass.h
@@ -27,9 +27,8 @@ namespace Beeps
 
 		void tick (Signals* signals)
 		{
-			uint nchannels   = signals->nchannels();
-			Signals filtered = Signals_create(
-				signals->nsamples(), nchannels, signals->sample_rate());
+			uint nchannels = signals->nchannels();
+			Signals filtered(signals->nsamples(), nchannels, signals->sample_rate());
 
 			Signals_tick(
 				&filtered, *signals,

--- a/rays-video/ext/rays-video/video.cpp
+++ b/rays-video/ext/rays-video/video.cpp
@@ -171,6 +171,50 @@ RUCY_DEF1(at, index)
 RUCY_END
 
 static
+RUCY_DEF0(play)
+{
+	CHECK;
+	THIS->play();
+	return self;
+}
+RUCY_END
+
+static
+RUCY_DEF0(pause)
+{
+	CHECK;
+	THIS->pause();
+	return self;
+}
+RUCY_END
+
+static
+RUCY_DEF0(stop)
+{
+	CHECK;
+	THIS->stop();
+	return self;
+}
+RUCY_END
+
+static
+RUCY_DEF1(set_time_scale, scale)
+{
+	CHECK;
+	THIS->set_time_scale(to<float>(scale));
+	return scale;
+}
+RUCY_END
+
+static
+RUCY_DEF0(get_time_scale)
+{
+	CHECK;
+	return value(THIS->time_scale());
+}
+RUCY_END
+
+static
 RUCY_DEF1(load, path)
 {
 	return value(Rays::load_video(path.c_str()));
@@ -211,6 +255,11 @@ Init_rays_video ()
 	cVideo.define_method("empty?",        empty);
 	cVideo.define_method("position=", set_position);
 	cVideo.define_method("position",  get_position);
+	cVideo.define_method("play",  play);
+	cVideo.define_method("pause", pause);
+	cVideo.define_method("stop",  stop);
+	cVideo.define_method("time_scale=", set_time_scale);
+	cVideo.define_method("time_scale",  get_time_scale);
 	cVideo.define_method("each!", each);
 	cVideo.define_method("to_image", to_image);
 	cVideo.define_method("[]", at);

--- a/rays-video/include/rays/video.h
+++ b/rays-video/include/rays/video.h
@@ -44,6 +44,16 @@ namespace Rays
 
 			void remove (size_t index);
 
+			void play ();
+
+			void pause ();
+
+			void stop ();
+
+			void set_time_scale (float scale);
+
+			float    time_scale () const;
+
 			void save (const char* path);
 
 			coord width () const;

--- a/rays-video/lib/rays/video.rb
+++ b/rays-video/lib/rays/video.rb
@@ -1,4 +1,6 @@
 require 'xot/block_util'
+require 'beeps/ext'
+require 'rays/ext'
 require 'rays-video/ext'
 
 

--- a/rays-video/src/ios/video.mm
+++ b/rays-video/src/ios/video.mm
@@ -8,6 +8,7 @@
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #include "rays/bitmap.h"
 #include "rays/exception.h"
+#include "video_audio_in.h"
 
 
 namespace Rays
@@ -19,7 +20,12 @@ namespace Rays
 
 		virtual ~Data () {}
 
-		virtual Image decode (size_t index, float pixel_density) const = 0;
+		virtual Image decode_image (size_t index, float pixel_density) const = 0;
+
+		virtual VideoAudioInList get_audio_tracks () const
+		{
+			return {};
+		}
 
 		virtual coord width () const   = 0;
 
@@ -95,7 +101,7 @@ namespace Rays
 			[asset       release];
 		}
 
-		Image decode (size_t index, float pixel_density) const override
+		Image decode_image (size_t index, float pixel_density) const override
 		{
 			AVAssetImageGenerator* generator =
 				[[[AVAssetImageGenerator alloc] initWithAsset: asset] autorelease];
@@ -116,6 +122,20 @@ namespace Rays
 			}
 
 			return Image(to_bitmap(cgimage.get()), pixel_density);
+		}
+
+		VideoAudioInList get_audio_tracks () const override
+		{
+			NSArray<AVAssetTrack*>* tracks =
+				[asset tracksWithMediaType: AVMediaTypeAudio];
+			if (!tracks || tracks.count == 0)
+				return {};
+
+			VideoAudioInList list;
+			for (AVAssetTrack* track in tracks)
+				list.emplace_back(new VideoAudioIn(VideoAudioIn_Data_create(asset, track)));
+
+			return list;
 		}
 
 		coord width () const override
@@ -187,7 +207,7 @@ namespace Rays
 			this->fps_   = delay > 0 ? std::round(1 / delay) : DEFAULT_FPS;
 		}
 
-		Image decode (size_t index, float pixel_density) const override
+		Image decode_image (size_t index, float pixel_density) const override
 		{
 			std::shared_ptr<CGImage> cgimage(
 				CGImageSourceCreateImageAtIndex(source.get(), index, NULL),
@@ -288,12 +308,19 @@ namespace Rays
 	}
 
 	Image
-	VideoReader::decode (size_t index, float pixel_density) const
+	VideoReader::decode_image (size_t index, float pixel_density) const
 	{
 		if (!*this)
 			invalid_state_error(__FILE__, __LINE__);
 
-		return self->decode(index, pixel_density);
+		return self->decode_image(index, pixel_density);
+	}
+
+	VideoAudioInList
+	VideoReader::get_audio_tracks () const
+	{
+		if (!*this) return {};
+		return self->get_audio_tracks();
 	}
 
 	coord

--- a/rays-video/src/ios/video_audio_in.h
+++ b/rays-video/src/ios/video_audio_in.h
@@ -1,0 +1,22 @@
+// -*- mode: objc -*-
+#pragma once
+#ifndef __RAYS_VIDEO_SRC_IOS_VIDEO_AUDIO_IN_H__
+#define __RAYS_VIDEO_SRC_IOS_VIDEO_AUDIO_IN_H__
+
+
+#import <AVFoundation/AVFoundation.h>
+#include "../video_audio_in.h"
+
+
+namespace Rays
+{
+
+
+	VideoAudioIn::Data* VideoAudioIn_Data_create (
+		AVAsset* asset, AVAssetTrack* audio_track);
+
+
+}// Rays
+
+
+#endif//EOH

--- a/rays-video/src/ios/video_audio_in.mm
+++ b/rays-video/src/ios/video_audio_in.mm
@@ -1,0 +1,252 @@
+// -*- mode: objc -*-
+#import "video_audio_in.h"
+
+
+#import <AVFoundation/AVFoundation.h>
+#include "rays/exception.h"
+
+
+namespace Rays
+{
+
+
+	struct VideoAudioIn::Data
+	{
+
+		AVAsset* asset            = nil;
+
+		AVAssetTrack* audio_track = nil;
+
+		uint nsamples = 0;
+
+		Beeps::Signals buffer;
+
+		uint           buffer_offset = 0;
+
+		AVAssetReader* reader               = nil;
+
+		AVAssetReaderAudioMixOutput* output = nil;
+
+		Data (AVAsset* asset, AVAssetTrack* audio_track)
+		{
+			assert(asset && audio_track);
+
+			CMFormatDescriptionRef format =
+				(__bridge CMFormatDescriptionRef) audio_track.formatDescriptions.firstObject;
+			if (!format)
+				rays_error(__FILE__, __LINE__, "failed to get CMFormatDescription");
+
+			const AudioStreamBasicDescription* desc =
+				CMAudioFormatDescriptionGetStreamBasicDescription(format);
+			if (!desc)
+				rays_error(__FILE__, __LINE__, "failed to get AudioStreamBasicDescription");
+
+			this->asset       = [asset       retain];
+			this->audio_track = [audio_track retain];
+			uint nchannels    = std::min<uint>(desc->mChannelsPerFrame, 2);
+			this->buffer      = Beeps::Signals(2048, nchannels, desc->mSampleRate);
+			double duration   = CMTimeGetSeconds(audio_track.timeRange.duration);
+			this->nsamples    = (uint) (duration * buffer.sample_rate());
+		}
+
+		~Data ()
+		{
+			clear_reader();
+			[audio_track release];
+			[asset       release];
+		}
+
+		void create_reader (uint offset)
+		{
+			clear_reader();
+
+			NSError* error        = nil;
+			AVAssetReader* reader =
+				[[[AVAssetReader alloc] initWithAsset: asset error: &error] autorelease];
+			if (!reader || error)
+				rays_error(__FILE__, __LINE__, "failed to create AVAssetReader");
+
+			AVAssetReaderAudioMixOutput* output = [AVAssetReaderAudioMixOutput
+				assetReaderAudioMixOutputWithAudioTracks: @[audio_track]
+				audioSettings: @{
+					AVFormatIDKey:               @(kAudioFormatLinearPCM),
+					AVLinearPCMBitDepthKey:      @32,
+					AVLinearPCMIsFloatKey:       @YES,
+					AVLinearPCMIsNonInterleaved: @YES,
+					AVNumberOfChannelsKey:       @(buffer.nchannels()),
+				}];
+			if (![reader canAddOutput: output])
+				rays_error(__FILE__, __LINE__, "cannot add audio output");
+
+			[reader addOutput: output];
+			reader.timeRange = CMTimeRangeMake(
+				CMTimeMakeWithSeconds(
+					(double) offset / buffer.sample_rate(),
+					(int32_t) buffer.sample_rate()),
+				kCMTimePositiveInfinity);
+			if (![reader startReading])
+				rays_error(__FILE__, __LINE__, "failed to start reading audio");
+
+			this->reader        = [reader retain];
+			this->output        = [output retain];
+			this->buffer_offset = offset;
+			this->buffer        .clear();
+		}
+
+		void clear_reader ()
+		{
+			if (reader && reader.status == AVAssetReaderStatusReading)
+				[reader cancelReading];
+
+			[output release];
+			output = nil;
+			[reader release];
+			reader = nil;
+		}
+
+		bool read_next (Beeps::Signals* signals, uint* offset)
+		{
+			assert(signals && offset);
+
+			if (
+				!reader ||
+				*offset < buffer_offset ||
+				*offset > buffer_offset + buffer.nsamples())
+			{
+				create_reader(*offset);
+			}
+
+			if (*offset == buffer_offset + buffer.nsamples())
+			{
+				if (!read_next_buffer()) return false;
+				buffer_offset = *offset;
+			}
+
+			uint size = signals->append(buffer, *offset - buffer_offset);
+			*offset += size;
+			return size > 0;
+		}
+
+		bool read_next_buffer ()
+		{
+			if (!reader || !output || reader.status != AVAssetReaderStatusReading)
+				return false;
+
+			std::shared_ptr<opaqueCMSampleBuffer> samples(
+				[output copyNextSampleBuffer],
+				CFRelease);
+			if (!samples)
+				return false;
+
+			uint nsamples = (uint) CMSampleBufferGetNumSamples(samples.get());
+			if (nsamples <= 0)
+				return false;
+
+			CMBlockBufferRef block = CMSampleBufferGetDataBuffer(samples.get());
+			if (!block)
+				return false;
+
+			size_t size = CMBlockBufferGetDataLength(block);
+			char* data  = NULL;
+			CMBlockBufferGetDataPointer(block, 0, NULL, &size, &data);
+			if (!data || size <= 0)
+				rays_error(__FILE__, __LINE__);
+
+			CMFormatDescriptionRef format =
+				CMSampleBufferGetFormatDescription(samples.get());
+			if (!format)
+				rays_error(__FILE__, __LINE__);
+
+			const AudioStreamBasicDescription* desc =
+				CMAudioFormatDescriptionGetStreamBasicDescription(format);
+			if (!desc)
+				rays_error(__FILE__, __LINE__);
+
+			uint nchannels = desc->mChannelsPerFrame;
+			if (nchannels != buffer.nchannels())
+				rays_error(__FILE__, __LINE__);
+
+			std::vector<const float*> channels(nchannels);
+			for (uint ch = 0; ch < nchannels; ++ch)
+				channels[ch] = (const float*) data + ch * nsamples;
+
+			buffer.clear(nsamples);
+			buffer.append(channels.data(), nsamples, nchannels, buffer.sample_rate());
+			return buffer.nsamples() > 0;
+		}
+
+	};// VideoAudioIn::Data
+
+
+	VideoAudioIn::Data*
+	VideoAudioIn_Data_create (AVAsset* asset, AVAssetTrack* audio_track)
+	{
+		return new VideoAudioIn::Data(asset, audio_track);
+	}
+
+
+	VideoAudioIn::VideoAudioIn (Data* data)
+	:	self(data)
+	{
+	}
+
+	VideoAudioIn::~VideoAudioIn ()
+	{
+	}
+
+	double
+	VideoAudioIn::sample_rate () const
+	{
+		return self->buffer.sample_rate();
+	}
+
+	uint
+	VideoAudioIn::nchannels () const
+	{
+		return self->buffer.nchannels();
+	}
+
+	uint
+	VideoAudioIn::nsamples () const
+	{
+		return self->nsamples;
+	}
+
+	float
+	VideoAudioIn::seconds () const
+	{
+		if (this->sample_rate() <= 0)
+			return 0;
+
+		return (float) (self->nsamples / this->sample_rate());
+	}
+
+	VideoAudioIn::operator bool () const
+	{
+		return
+			Super::operator bool() &&
+			self->asset &&
+			self->audio_track &&
+			self->buffer;
+	}
+
+	bool
+	VideoAudioIn::seekable () const
+	{
+		return true;
+	}
+
+	void
+	VideoAudioIn::generate (Context* context, Beeps::Signals* signals, uint* offset)
+	{
+		Super::generate(context, signals, offset);
+
+		while (!signals->full())
+		{
+			if (!self->read_next(signals, offset))
+				break;
+		}
+	}
+
+
+}// Rays

--- a/rays-video/src/osx/video.mm
+++ b/rays-video/src/osx/video.mm
@@ -8,6 +8,7 @@
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #include "rays/bitmap.h"
 #include "rays/exception.h"
+#include "video_audio_in.h"
 
 
 namespace Rays
@@ -20,6 +21,11 @@ namespace Rays
 		virtual ~Data () {}
 
 		virtual Image decode_image (size_t index, float pixel_density) const = 0;
+
+		virtual VideoAudioInList get_audio_tracks () const
+		{
+			return {};
+		}
 
 		virtual coord width () const   = 0;
 
@@ -116,6 +122,20 @@ namespace Rays
 			}
 
 			return Image(to_bitmap(cgimage.get()), pixel_density);
+		}
+
+		VideoAudioInList get_audio_tracks () const override
+		{
+			NSArray<AVAssetTrack*>* tracks =
+				[asset tracksWithMediaType: AVMediaTypeAudio];
+			if (!tracks || tracks.count == 0)
+				return {};
+
+			VideoAudioInList list;
+			for (AVAssetTrack* track in tracks)
+				list.emplace_back(new VideoAudioIn(VideoAudioIn_Data_create(asset, track)));
+
+			return list;
 		}
 
 		coord width () const override
@@ -294,6 +314,13 @@ namespace Rays
 			invalid_state_error(__FILE__, __LINE__);
 
 		return self->decode_image(index, pixel_density);
+	}
+
+	VideoAudioInList
+	VideoReader::get_audio_tracks () const
+	{
+		if (!*this) return {};
+		return self->get_audio_tracks();
 	}
 
 	coord

--- a/rays-video/src/osx/video.mm
+++ b/rays-video/src/osx/video.mm
@@ -19,7 +19,7 @@ namespace Rays
 
 		virtual ~Data () {}
 
-		virtual Image decode (size_t index, float pixel_density) const = 0;
+		virtual Image decode_image (size_t index, float pixel_density) const = 0;
 
 		virtual coord width () const   = 0;
 
@@ -95,7 +95,7 @@ namespace Rays
 			[asset       release];
 		}
 
-		Image decode (size_t index, float pixel_density) const override
+		Image decode_image (size_t index, float pixel_density) const override
 		{
 			AVAssetImageGenerator* generator =
 				[[[AVAssetImageGenerator alloc] initWithAsset: asset] autorelease];
@@ -187,7 +187,7 @@ namespace Rays
 			this->fps_   = delay > 0 ? std::round(1 / delay) : DEFAULT_FPS;
 		}
 
-		Image decode (size_t index, float pixel_density) const override
+		Image decode_image (size_t index, float pixel_density) const override
 		{
 			std::shared_ptr<CGImage> cgimage(
 				CGImageSourceCreateImageAtIndex(source.get(), index, NULL),
@@ -288,12 +288,12 @@ namespace Rays
 	}
 
 	Image
-	VideoReader::decode (size_t index, float pixel_density) const
+	VideoReader::decode_image (size_t index, float pixel_density) const
 	{
 		if (!*this)
 			invalid_state_error(__FILE__, __LINE__);
 
-		return self->decode(index, pixel_density);
+		return self->decode_image(index, pixel_density);
 	}
 
 	coord

--- a/rays-video/src/osx/video_audio_in.h
+++ b/rays-video/src/osx/video_audio_in.h
@@ -1,0 +1,22 @@
+// -*- mode: objc -*-
+#pragma once
+#ifndef __RAYS_VIDEO_SRC_OSX_VIDEO_AUDIO_IN_H__
+#define __RAYS_VIDEO_SRC_OSX_VIDEO_AUDIO_IN_H__
+
+
+#import <AVFoundation/AVFoundation.h>
+#include "../video_audio_in.h"
+
+
+namespace Rays
+{
+
+
+	VideoAudioIn::Data* VideoAudioIn_Data_create (
+		AVAsset* asset, AVAssetTrack* audio_track);
+
+
+}// Rays
+
+
+#endif//EOH

--- a/rays-video/src/osx/video_audio_in.mm
+++ b/rays-video/src/osx/video_audio_in.mm
@@ -1,5 +1,5 @@
 // -*- mode: objc -*-
-#import "../video_audio_in.h"
+#import "video_audio_in.h"
 
 
 #import <AVFoundation/AVFoundation.h>
@@ -43,7 +43,8 @@ namespace Rays
 
 			this->asset       = [asset       retain];
 			this->audio_track = [audio_track retain];
-			this->buffer      = Beeps::Signals(2048, desc->mChannelsPerFrame, desc->mSampleRate);
+			uint nchannels    = std::min<uint>(desc->mChannelsPerFrame, 2);
+			this->buffer      = Beeps::Signals(2048, nchannels, desc->mSampleRate);
 			double duration   = CMTimeGetSeconds(audio_track.timeRange.duration);
 			this->nsamples    = (uint) (duration * buffer.sample_rate());
 		}
@@ -72,6 +73,7 @@ namespace Rays
 					AVLinearPCMBitDepthKey:      @32,
 					AVLinearPCMIsFloatKey:       @YES,
 					AVLinearPCMIsNonInterleaved: @YES,
+					AVNumberOfChannelsKey:       @(buffer.nchannels()),
 				}];
 			if (![reader canAddOutput: output])
 				rays_error(__FILE__, __LINE__, "cannot add audio output");
@@ -174,6 +176,13 @@ namespace Rays
 		}
 
 	};// VideoAudioIn::Data
+
+
+	VideoAudioIn::Data*
+	VideoAudioIn_Data_create (AVAsset* asset, AVAssetTrack* audio_track)
+	{
+		return new VideoAudioIn::Data(asset, audio_track);
+	}
 
 
 	VideoAudioIn::VideoAudioIn (Data* data)

--- a/rays-video/src/osx/video_audio_in.mm
+++ b/rays-video/src/osx/video_audio_in.mm
@@ -1,0 +1,243 @@
+// -*- mode: objc -*-
+#import "../video_audio_in.h"
+
+
+#import <AVFoundation/AVFoundation.h>
+#include "rays/exception.h"
+
+
+namespace Rays
+{
+
+
+	struct VideoAudioIn::Data
+	{
+
+		AVAsset* asset            = nil;
+
+		AVAssetTrack* audio_track = nil;
+
+		uint nsamples = 0;
+
+		Beeps::Signals buffer;
+
+		uint           buffer_offset = 0;
+
+		AVAssetReader* reader               = nil;
+
+		AVAssetReaderAudioMixOutput* output = nil;
+
+		Data (AVAsset* asset, AVAssetTrack* audio_track)
+		{
+			assert(asset && audio_track);
+
+			CMFormatDescriptionRef format =
+				(__bridge CMFormatDescriptionRef) audio_track.formatDescriptions.firstObject;
+			if (!format)
+				rays_error(__FILE__, __LINE__, "failed to get CMFormatDescription");
+
+			const AudioStreamBasicDescription* desc =
+				CMAudioFormatDescriptionGetStreamBasicDescription(format);
+			if (!desc)
+				rays_error(__FILE__, __LINE__, "failed to get AudioStreamBasicDescription");
+
+			this->asset       = [asset       retain];
+			this->audio_track = [audio_track retain];
+			this->buffer      = Beeps::Signals(2048, desc->mChannelsPerFrame, desc->mSampleRate);
+			double duration   = CMTimeGetSeconds(audio_track.timeRange.duration);
+			this->nsamples    = (uint) (duration * buffer.sample_rate());
+		}
+
+		~Data ()
+		{
+			clear_reader();
+			[audio_track release];
+			[asset       release];
+		}
+
+		void create_reader (uint offset)
+		{
+			clear_reader();
+
+			NSError* error        = nil;
+			AVAssetReader* reader =
+				[[[AVAssetReader alloc] initWithAsset: asset error: &error] autorelease];
+			if (!reader || error)
+				rays_error(__FILE__, __LINE__, "failed to create AVAssetReader");
+
+			AVAssetReaderAudioMixOutput* output = [AVAssetReaderAudioMixOutput
+				assetReaderAudioMixOutputWithAudioTracks: @[audio_track]
+				audioSettings: @{
+					AVFormatIDKey:               @(kAudioFormatLinearPCM),
+					AVLinearPCMBitDepthKey:      @32,
+					AVLinearPCMIsFloatKey:       @YES,
+					AVLinearPCMIsNonInterleaved: @YES,
+				}];
+			if (![reader canAddOutput: output])
+				rays_error(__FILE__, __LINE__, "cannot add audio output");
+
+			[reader addOutput: output];
+			reader.timeRange = CMTimeRangeMake(
+				CMTimeMakeWithSeconds(
+					(double) offset / buffer.sample_rate(),
+					(int32_t) buffer.sample_rate()),
+				kCMTimePositiveInfinity);
+			if (![reader startReading])
+				rays_error(__FILE__, __LINE__, "failed to start reading audio");
+
+			this->reader        = [reader retain];
+			this->output        = [output retain];
+			this->buffer_offset = offset;
+			this->buffer        .clear();
+		}
+
+		void clear_reader ()
+		{
+			if (reader && reader.status == AVAssetReaderStatusReading)
+				[reader cancelReading];
+
+			[output release];
+			output = nil;
+			[reader release];
+			reader = nil;
+		}
+
+		bool read_next (Beeps::Signals* signals, uint* offset)
+		{
+			assert(signals && offset);
+
+			if (
+				!reader ||
+				*offset < buffer_offset ||
+				*offset > buffer_offset + buffer.nsamples())
+			{
+				create_reader(*offset);
+			}
+
+			if (*offset == buffer_offset + buffer.nsamples())
+			{
+				if (!read_next_buffer()) return false;
+				buffer_offset = *offset;
+			}
+
+			uint size = signals->append(buffer, *offset - buffer_offset);
+			*offset += size;
+			return size > 0;
+		}
+
+		bool read_next_buffer ()
+		{
+			if (!reader || !output || reader.status != AVAssetReaderStatusReading)
+				return false;
+
+			std::shared_ptr<opaqueCMSampleBuffer> samples(
+				[output copyNextSampleBuffer],
+				CFRelease);
+			if (!samples)
+				return false;
+
+			uint nsamples = (uint) CMSampleBufferGetNumSamples(samples.get());
+			if (nsamples <= 0)
+				return false;
+
+			CMBlockBufferRef block = CMSampleBufferGetDataBuffer(samples.get());
+			if (!block)
+				return false;
+
+			size_t size = CMBlockBufferGetDataLength(block);
+			char* data  = NULL;
+			CMBlockBufferGetDataPointer(block, 0, NULL, &size, &data);
+			if (!data || size <= 0)
+				rays_error(__FILE__, __LINE__);
+
+			CMFormatDescriptionRef format =
+				CMSampleBufferGetFormatDescription(samples.get());
+			if (!format)
+				rays_error(__FILE__, __LINE__);
+
+			const AudioStreamBasicDescription* desc =
+				CMAudioFormatDescriptionGetStreamBasicDescription(format);
+			if (!desc)
+				rays_error(__FILE__, __LINE__);
+
+			uint nchannels = desc->mChannelsPerFrame;
+			if (nchannels != buffer.nchannels())
+				rays_error(__FILE__, __LINE__);
+
+			std::vector<const float*> channels(nchannels);
+			for (uint ch = 0; ch < nchannels; ++ch)
+				channels[ch] = (const float*) data + ch * nsamples;
+
+			buffer.clear(nsamples);
+			buffer.append(channels.data(), nsamples, nchannels, buffer.sample_rate());
+			return buffer.nsamples() > 0;
+		}
+
+	};// VideoAudioIn::Data
+
+
+	VideoAudioIn::VideoAudioIn (Data* data)
+	:	self(data)
+	{
+	}
+
+	VideoAudioIn::~VideoAudioIn ()
+	{
+	}
+
+	double
+	VideoAudioIn::sample_rate () const
+	{
+		return self->buffer.sample_rate();
+	}
+
+	uint
+	VideoAudioIn::nchannels () const
+	{
+		return self->buffer.nchannels();
+	}
+
+	uint
+	VideoAudioIn::nsamples () const
+	{
+		return self->nsamples;
+	}
+
+	float
+	VideoAudioIn::seconds () const
+	{
+		if (this->sample_rate() <= 0)
+			return 0;
+
+		return (float) (self->nsamples / this->sample_rate());
+	}
+
+	VideoAudioIn::operator bool () const
+	{
+		return
+			Super::operator bool() &&
+			self->asset &&
+			self->audio_track &&
+			self->buffer;
+	}
+
+	bool
+	VideoAudioIn::seekable () const
+	{
+		return true;
+	}
+
+	void
+	VideoAudioIn::generate (Context* context, Beeps::Signals* signals, uint* offset)
+	{
+		Super::generate(context, signals, offset);
+
+		while (!signals->full())
+		{
+			if (!self->read_next(signals, offset))
+				break;
+		}
+	}
+
+
+}// Rays

--- a/rays-video/src/sdl/video.cpp
+++ b/rays-video/src/sdl/video.cpp
@@ -23,9 +23,15 @@ namespace Rays
 	}
 
 	Image
-	VideoReader::decode (size_t, float) const
+	VideoReader::decode_image (size_t, float) const
 	{
 		not_implemented_error(__FILE__, __LINE__);
+	}
+
+	VideoAudioInList
+	VideoReader::get_audio_tracks () const
+	{
+		return {};
 	}
 
 	coord

--- a/rays-video/src/sdl/video_audio_in.cpp
+++ b/rays-video/src/sdl/video_audio_in.cpp
@@ -1,0 +1,63 @@
+#include "../video_audio_in.h"
+
+
+namespace Rays
+{
+
+
+	struct VideoAudioIn::Data
+	{
+	};// VideoAudioIn::Data
+
+
+	VideoAudioIn::VideoAudioIn (Data* data)
+	:	self(data)
+	{
+	}
+
+	VideoAudioIn::~VideoAudioIn ()
+	{
+	}
+
+	double
+	VideoAudioIn::sample_rate () const
+	{
+		return 0;
+	}
+
+	uint
+	VideoAudioIn::nchannels () const
+	{
+		return 0;
+	}
+
+	uint
+	VideoAudioIn::nsamples () const
+	{
+		return 0;
+	}
+
+	float
+	VideoAudioIn::seconds () const
+	{
+		return 0;
+	}
+
+	VideoAudioIn::operator bool () const
+	{
+		return false;
+	}
+
+	bool
+	VideoAudioIn::seekable () const
+	{
+		return false;
+	}
+
+	void
+	VideoAudioIn::generate (Context* context, Beeps::Signals* signals, uint* offset)
+	{
+	}
+
+
+}// Rays

--- a/rays-video/src/video.cpp
+++ b/rays-video/src/video.cpp
@@ -1,6 +1,9 @@
 #include "video.h"
 
 
+#include <xot/util.h>
+#include <beeps/sound.h>
+#include "rays/bitmap.h"
 #include "rays/exception.h"
 
 
@@ -19,6 +22,10 @@ namespace Rays
 
 		std::vector<Image> images;
 
+		VideoAudioInList audio_tracks;
+
+		Beeps::SoundPlayer player;
+
 	};// Video::Data
 
 
@@ -36,7 +43,10 @@ namespace Rays
 
 		void preprocess (const Image* image) const override
 		{
-			const_cast<Image*>(image)->self = reader.decode(index, 1).self;
+			Image decoded = reader.decode_image(index, 1);
+			Bitmap bitmap = decoded.bitmap();
+			if (bitmap) Xot::hint_memory_usage(bitmap.size());
+			const_cast<Image*>(image)->self = decoded.self;
 		}
 
 	};// VideoImageData
@@ -61,6 +71,8 @@ namespace Rays
 		self->images.reserve(size);
 		for (size_t i = 0; i < size; ++i)
 			self->images.push_back(Image(new VideoImageData(reader, i)));
+
+		self->audio_tracks = reader.get_audio_tracks();
 
 		return video;
 	}
@@ -119,6 +131,43 @@ namespace Rays
 	{
 		if (index >= size()) return;
 		self->images.erase(self->images.begin() + index);
+	}
+
+	void
+	Video::play ()
+	{
+		if (empty())
+			invalid_state_error(__FILE__, __LINE__, "video is empty");
+
+		if (self->audio_tracks.empty())
+			invalid_state_error(__FILE__, __LINE__, "playing video without audio is not yet supported");
+
+		VideoAudioIn* in = self->audio_tracks[0].get();
+		self->player = Beeps::Sound(in, 0, in->nchannels(), in->sample_rate()).play();
+	}
+
+	void
+	Video::pause ()
+	{
+		if (self->player) self->player.pause();
+	}
+
+	void
+	Video::stop ()
+	{
+		if (self->player) self->player.stop();
+	}
+
+	void
+	Video::set_time_scale (float scale)
+	{
+		if (self->player) self->player.set_time_scale(scale);
+	}
+
+	float
+	Video::time_scale () const
+	{
+		return self->player ? self->player.time_scale() : 1;
 	}
 
 	coord
@@ -205,6 +254,12 @@ namespace Rays
 
 	Video::operator Image () const
 	{
+		if (self->player)
+		{
+			size_t index = (size_t) (self->player.time() * self->fps);
+			if (index >= size()) index = size() - 1;
+			self->position = index;
+		}
 		return operator[](self->position);
 	}
 

--- a/rays-video/src/video.h
+++ b/rays-video/src/video.h
@@ -5,6 +5,7 @@
 
 
 #include "rays/video.h"
+#include "video_audio_in.h"
 
 
 namespace Rays
@@ -21,6 +22,8 @@ namespace Rays
 			VideoReader (const char* path);
 
 			Image decode_image (size_t index, float pixel_density) const;
+
+			VideoAudioInList get_audio_tracks () const;
 
 			coord width () const;
 

--- a/rays-video/src/video.h
+++ b/rays-video/src/video.h
@@ -20,7 +20,7 @@ namespace Rays
 
 			VideoReader (const char* path);
 
-			Image decode (size_t index, float pixel_density) const;
+			Image decode_image (size_t index, float pixel_density) const;
 
 			coord width () const;
 

--- a/rays-video/src/video_audio_in.h
+++ b/rays-video/src/video_audio_in.h
@@ -4,6 +4,7 @@
 #define __RAYS_VIDEO_SRC_VIDEO_AUDIO_IN_H__
 
 
+#include <vector>
 #include <beeps/processor.h>
 
 
@@ -44,6 +45,9 @@ namespace Rays
 				Context* context, Beeps::Signals* signals, uint* offset) override;
 
 	};// VideoAudioIn
+
+
+	typedef std::vector<Xot::Ref<VideoAudioIn>> VideoAudioInList;
 
 
 }// Rays

--- a/rays-video/src/video_audio_in.h
+++ b/rays-video/src/video_audio_in.h
@@ -1,0 +1,52 @@
+// -*- c++ -*-
+#pragma once
+#ifndef __RAYS_VIDEO_SRC_VIDEO_AUDIO_IN_H__
+#define __RAYS_VIDEO_SRC_VIDEO_AUDIO_IN_H__
+
+
+#include <beeps/processor.h>
+
+
+namespace Rays
+{
+
+
+	class VideoAudioIn : public Beeps::Generator
+	{
+
+		typedef Beeps::Generator Super;
+
+		public:
+
+			virtual ~VideoAudioIn ();
+
+			virtual double sample_rate () const;
+
+			virtual uint nchannels () const;
+
+			virtual uint nsamples () const;
+
+			virtual float seconds () const;
+
+			virtual operator bool () const override;
+
+			bool seekable () const override;
+
+			struct Data;
+
+			Xot::PSharedImpl<Data> self;
+
+			VideoAudioIn (Data* data);
+
+		protected:
+
+			virtual void generate (
+				Context* context, Beeps::Signals* signals, uint* offset) override;
+
+	};// VideoAudioIn
+
+
+}// Rays
+
+
+#endif//EOH

--- a/rays-video/src/video_audio_in.h
+++ b/rays-video/src/video_audio_in.h
@@ -6,6 +6,7 @@
 
 #include <vector>
 #include <beeps/processor.h>
+#include <rays/defs.h>
 
 
 namespace Rays

--- a/rays-video/src/win32/video.cpp
+++ b/rays-video/src/win32/video.cpp
@@ -23,9 +23,15 @@ namespace Rays
 	}
 
 	Image
-	VideoReader::decode (size_t, float) const
+	VideoReader::decode_image (size_t, float) const
 	{
 		not_implemented_error(__FILE__, __LINE__);
+	}
+
+	VideoAudioInList
+	VideoReader::get_audio_tracks () const
+	{
+		return {};
 	}
 
 	coord

--- a/rays-video/src/win32/video_audio_in.cpp
+++ b/rays-video/src/win32/video_audio_in.cpp
@@ -1,0 +1,63 @@
+#include "../video_audio_in.h"
+
+
+namespace Rays
+{
+
+
+	struct VideoAudioIn::Data
+	{
+	};// VideoAudioIn::Data
+
+
+	VideoAudioIn::VideoAudioIn (Data* data)
+	:	self(data)
+	{
+	}
+
+	VideoAudioIn::~VideoAudioIn ()
+	{
+	}
+
+	double
+	VideoAudioIn::sample_rate () const
+	{
+		return 0;
+	}
+
+	uint
+	VideoAudioIn::nchannels () const
+	{
+		return 0;
+	}
+
+	uint
+	VideoAudioIn::nsamples () const
+	{
+		return 0;
+	}
+
+	float
+	VideoAudioIn::seconds () const
+	{
+		return 0;
+	}
+
+	VideoAudioIn::operator bool () const
+	{
+		return false;
+	}
+
+	bool
+	VideoAudioIn::seekable () const
+	{
+		return false;
+	}
+
+	void
+	VideoAudioIn::generate (Context* context, Beeps::Signals* signals, uint* offset)
+	{
+	}
+
+
+}// Rays

--- a/rays-video/test/test_video.rb
+++ b/rays-video/test/test_video.rb
@@ -1,6 +1,9 @@
 require_relative 'helper'
 
 
+return unless osx? || ios?
+
+
 class TestVideo < Test::Unit::TestCase
 
   def video(w = 10, h = 10, fps = 0, pd = 1)

--- a/rucy/src/rucy.cpp
+++ b/rucy/src/rucy.cpp
@@ -2,6 +2,7 @@
 #include "rucy/rucy.h"
 
 
+#include <xot/util.h>
 #include "rucy/exception.h"
 
 
@@ -9,12 +10,26 @@ namespace Rucy
 {
 
 
+	static void
+	hint_memory_usage (ssize_t size)
+	{
+		rb_gc_adjust_memory_usage(size);
+
+		// rb_gc_adjust_memory_usage() uses MEMOP_TYPE_REALLOC internally,
+		// which increases malloc_increase but does not check the GC trigger.
+		// A tiny ruby_xmalloc() goes through MEMOP_TYPE_MALLOC and triggers
+		// GC when malloc_increase exceeds malloc_limit.
+		if (size > 0) ruby_xfree(ruby_xmalloc(1));
+	}
+
 	void
 	init ()
 	{
 		static bool done = false;
 		if (done) return;
 		done = true;
+
+		Xot::set_hint_memory_usage_fun(hint_memory_usage);
 
 		rucy_module();
 		native_error_class();

--- a/xot/include/xot/util.h
+++ b/xot/include/xot/util.h
@@ -5,6 +5,7 @@
 
 
 #include <stdint.h>
+#include <sys/types.h>
 #include <math.h>
 #include <assert.h>
 #include <xot/defs.h>
@@ -122,6 +123,13 @@ namespace Xot
 		const uintptr_t& intval = *(uintptr_t*) &pointer;
 		return intval & POINTER_FLAG;
 	}
+
+
+	typedef void (*HintMemoryUsageFun)(ssize_t);
+
+	void set_hint_memory_usage_fun (HintMemoryUsageFun fun);
+
+	void     hint_memory_usage (ssize_t size);
 
 
 #if defined(OSX) || defined(IOS)

--- a/xot/src/util.cpp
+++ b/xot/src/util.cpp
@@ -53,6 +53,22 @@ namespace Xot
 	}
 
 
+	static HintMemoryUsageFun hint_memory_usage_fun = NULL;
+
+	void
+	set_hint_memory_usage_fun (HintMemoryUsageFun fun)
+	{
+		hint_memory_usage_fun = fun;
+	}
+
+	void
+	hint_memory_usage (ssize_t size)
+	{
+		if (hint_memory_usage_fun && size != 0)
+			hint_memory_usage_fun(size);
+	}
+
+
 #if defined(OSX) || defined(IOS)
 
 	void


### PR DESCRIPTION
## Summary
- Add audio playback to Video class (play/pause/stop/time_scale)
- Extract audio tracks from video files via AVAssetReader with on-demand reading
- Downmix surround sound (5.1 etc.) to stereo for OpenAL compatibility
- Add adaptive stream buffering in Beeps to prevent audio underruns
- Add Signals public API (constructors, clear, append) to Beeps
- Add platform stubs for win32/SDL, skip TestVideo on unsupported platforms

## Test plan
- [x] Stereo video (lpf.mp4) plays with correct audio
- [x] 5.1 surround video (big_buck_bunny) downmixes and plays correctly
- [x] time_scale adjustment works during playback
- [x] Long video (test.mp4, ~9.5min) plays without audio crackling after adaptive buffering
- [x] Memory stays stable during playback (~250-370MB)
- [x] `rake rays-video test` passes on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)