### PR TITLE
reflex: Add view constraint mechanism based on Box2D joints

### DIFF
--- a/reflex/ext/reflex/chase_constraint.cpp
+++ b/reflex/ext/reflex/chase_constraint.cpp
@@ -1,0 +1,89 @@
+#include "reflex/ruby/constraint.h"
+
+
+#include <rays/ruby/point.h>
+#include "reflex/exception.h"
+#include "reflex/ruby/pin.h"
+#include "reflex/ruby/view.h"
+#include "defs.h"
+
+
+RUCY_DEFINE_WRAPPER_VALUE_FROM_TO(REFLEX_EXPORT, Reflex::ChaseConstraint)
+
+#define THIS  to<Reflex::ChaseConstraint*>(self)
+
+#define CHECK RUCY_CHECK_OBJ(Reflex::ChaseConstraint, self)
+
+
+static
+RUCY_DEF_ALLOC(alloc, klass)
+{
+	Reflex::reflex_error(
+		__FILE__, __LINE__, "can not instantiate ChaseConstraint class");
+}
+RUCY_END
+
+static
+RUCY_DEFN(set_target)
+{
+	CHECK;
+	THIS->set_target(to<Reflex::Pin>(argc, argv));
+}
+RUCY_END
+
+static
+RUCY_DEF0(get_target)
+{
+	CHECK;
+	return value(THIS->target());
+}
+RUCY_END
+
+static
+RUCY_DEF1(set_force, force)
+{
+	CHECK;
+	if (force.is_nil())
+		THIS->clear_force();
+	else
+		THIS->set_force(to<float>(force));
+}
+RUCY_END
+
+static
+RUCY_DEF0(get_force)
+{
+	CHECK;
+	return THIS->has_force() ? value(THIS->force()) : nil();
+}
+RUCY_END
+
+
+static Class cChaseConstraint;
+
+void
+Init_reflex_chase_constraint ()
+{
+	Module mReflex = define_module("Reflex");
+
+	cChaseConstraint = mReflex.define_class("ChaseConstraint", Reflex::constraint_class());
+	cChaseConstraint.define_alloc_func(alloc);
+	cChaseConstraint.define_method("target=", set_target);
+	cChaseConstraint.define_method("target",  get_target);
+	cChaseConstraint.define_method("force=", set_force);
+	cChaseConstraint.define_method("force",  get_force);
+}
+
+
+namespace Reflex
+{
+
+
+	Class
+	chase_constraint_class ()
+	{
+		return cChaseConstraint;
+	}
+
+
+}// Reflex

--- a/reflex/ext/reflex/constraint.cpp
+++ b/reflex/ext/reflex/constraint.cpp
@@ -1,0 +1,144 @@
+#include "reflex/ruby/constraint.h"
+
+
+#include <rays/ruby/point.h>
+#include "reflex/exception.h"
+#include "reflex/ruby/view.h"
+#include "reflex/ruby/pin.h"
+#include "defs.h"
+
+
+RUCY_DEFINE_WRAPPER_VALUE_FROM_TO(REFLEX_EXPORT, Reflex::Constraint)
+
+#define THIS  to<Reflex::Constraint*>(self)
+
+#define CHECK RUCY_CHECK_OBJ(Reflex::Constraint, self)
+
+
+static
+RUCY_DEF_ALLOC(alloc, klass)
+{
+	Reflex::reflex_error(
+		__FILE__, __LINE__, "can not instantiate Constraint class");
+}
+RUCY_END
+
+static
+RUCY_DEF0(remove)
+{
+	CHECK;
+	THIS->remove();
+	return self;
+}
+RUCY_END
+
+static
+RUCY_DEF1(get_pin, index)
+{
+	CHECK;
+	return value(THIS->pin(to<int>(index)));
+}
+RUCY_END
+
+static
+RUCY_DEF1(set_spring, hertz)
+{
+	CHECK;
+	THIS->set_spring(hertz ? to<float>(hertz) : 0);
+}
+RUCY_END
+
+static
+RUCY_DEF0(get_spring)
+{
+	CHECK;
+	float hertz = THIS->spring();
+	return hertz > 0 ? value(hertz) : nil();
+}
+RUCY_END
+
+static
+RUCY_DEF1(set_damping, ratio)
+{
+	CHECK;
+	THIS->set_damping(to<float>(ratio));
+}
+RUCY_END
+
+static
+RUCY_DEF0(get_damping)
+{
+	CHECK;
+	return value(THIS->damping());
+}
+RUCY_END
+
+static
+RUCY_DEF1(set_collide, state)
+{
+	CHECK;
+	THIS->set_collide(to<bool>(state));
+}
+RUCY_END
+
+static
+RUCY_DEF0(can_collide)
+{
+	CHECK;
+	return value(THIS->can_collide());
+}
+RUCY_END
+
+static
+RUCY_DEF0(is_removed)
+{
+	CHECK;
+	return value(THIS->is_removed());
+}
+RUCY_END
+
+static
+RUCY_DEF0(is_active)
+{
+	CHECK;
+	return value(THIS->operator bool());
+}
+RUCY_END
+
+
+static Class cConstraint;
+
+void
+Init_reflex_constraint ()
+{
+	Module mReflex = define_module("Reflex");
+
+	cConstraint = mReflex.define_class("Constraint");
+	cConstraint.define_alloc_func(alloc);
+	cConstraint.define_method("remove", remove);
+	cConstraint.define_private_method("get_pin", get_pin);
+	cConstraint.define_method("spring=",  set_spring);
+	cConstraint.define_method("spring",   get_spring);
+	cConstraint.define_method("damping=", set_damping);
+	cConstraint.define_method("damping",  get_damping);
+	cConstraint.define_method("collide=", set_collide);
+	cConstraint.define_method("collide?", can_collide);
+	cConstraint.define_method("removed?", is_removed);
+	cConstraint.define_method("active?",  is_active);
+
+	define_wrapper_equality_methods<Reflex::Constraint>(cConstraint);
+}
+
+
+namespace Reflex
+{
+
+
+	Class
+	constraint_class ()
+	{
+		return cConstraint;
+	}
+
+
+}// Reflex

--- a/reflex/ext/reflex/constraint.cpp
+++ b/reflex/ext/reflex/constraint.cpp
@@ -6,6 +6,7 @@
 #include "reflex/ruby/view.h"
 #include "reflex/ruby/pin.h"
 #include "defs.h"
+#include "selector.h"
 
 
 RUCY_DEFINE_WRAPPER_VALUE_FROM_TO(REFLEX_EXPORT, Reflex::Constraint)
@@ -126,6 +127,7 @@ Init_reflex_constraint ()
 	cConstraint.define_method("removed?", is_removed);
 	cConstraint.define_method("active?",  is_active);
 
+	define_selector_methods<Reflex::Constraint>(cConstraint);
 	define_wrapper_equality_methods<Reflex::Constraint>(cConstraint);
 }
 

--- a/reflex/ext/reflex/link_constraint.cpp
+++ b/reflex/ext/reflex/link_constraint.cpp
@@ -1,0 +1,151 @@
+#include "reflex/ruby/constraint.h"
+
+
+#include "reflex/exception.h"
+#include "defs.h"
+
+
+RUCY_DEFINE_WRAPPER_VALUE_FROM_TO(REFLEX_EXPORT, Reflex::LinkConstraint)
+
+#define THIS  to<Reflex::LinkConstraint*>(self)
+
+#define CHECK RUCY_CHECK_OBJ(Reflex::LinkConstraint, self)
+
+
+static
+RUCY_DEF_ALLOC(alloc, klass)
+{
+	Reflex::reflex_error(
+		__FILE__, __LINE__, "can not instantiate LinkConstraint class");
+}
+RUCY_END
+
+static
+RUCY_DEF1(set_distance, distance)
+{
+	CHECK;
+	if (distance.is_nil())
+		THIS->clear_distance();
+	else
+		THIS->set_distance(to<coord>(distance));
+}
+RUCY_END
+
+static
+RUCY_DEF0(get_distance)
+{
+	CHECK;
+	return value(THIS->distance());
+}
+RUCY_END
+
+static
+RUCY_DEF0(has_distance)
+{
+	CHECK;
+	return value(THIS->has_distance());
+}
+RUCY_END
+
+static
+RUCY_DEF0(current_distance)
+{
+	CHECK;
+	return value(THIS->current_distance());
+}
+RUCY_END
+
+static
+RUCY_DEF2(set_range, min, max)
+{
+	CHECK;
+	THIS->set_range(to<coord>(min), to<coord>(max));
+}
+RUCY_END
+
+static
+RUCY_DEF0(clear_range)
+{
+	CHECK;
+	THIS->clear_range();
+}
+RUCY_END
+
+static
+RUCY_DEF0(range_min)
+{
+	CHECK;
+	return value(THIS->range_min());
+}
+RUCY_END
+
+static
+RUCY_DEF0(range_max)
+{
+	CHECK;
+	return value(THIS->range_max());
+}
+RUCY_END
+
+static
+RUCY_DEF0(has_range)
+{
+	CHECK;
+	return value(THIS->has_range());
+}
+RUCY_END
+
+static
+RUCY_DEF1(set_motor, pixel_per_second)
+{
+	CHECK;
+	if (pixel_per_second.is_nil())
+		THIS->clear_motor();
+	else
+		THIS->set_motor(to<coord>(pixel_per_second));
+}
+RUCY_END
+
+static
+RUCY_DEF0(get_motor)
+{
+	CHECK;
+	return THIS->has_motor() ? value(THIS->motor()) : nil();
+}
+RUCY_END
+
+
+static Class cLinkConstraint;
+
+void
+Init_reflex_link_constraint ()
+{
+	Module mReflex = define_module("Reflex");
+
+	cLinkConstraint = mReflex.define_class("LinkConstraint", Reflex::constraint_class());
+	cLinkConstraint.define_alloc_func(alloc);
+	cLinkConstraint.define_method(        "distance=", set_distance);
+	cLinkConstraint.define_method(        "distance",  get_distance);
+	cLinkConstraint.define_method("current_distance", current_distance);
+	cLinkConstraint.define_private_method(  "set_range!",   set_range);
+	cLinkConstraint.define_private_method("clear_range!", clear_range);
+	cLinkConstraint.define_private_method(      "range_min!",   range_min);
+	cLinkConstraint.define_private_method(      "range_max!",   range_max);
+	cLinkConstraint.define_private_method(  "has_range!",   has_range);
+	cLinkConstraint.define_method("motor=", set_motor);
+	cLinkConstraint.define_method("motor",  get_motor);
+}
+
+
+namespace Reflex
+{
+
+
+	Class
+	link_constraint_class ()
+	{
+		return cLinkConstraint;
+	}
+
+
+}// Reflex

--- a/reflex/ext/reflex/native.cpp
+++ b/reflex/ext/reflex/native.cpp
@@ -35,6 +35,13 @@ void Init_reflex_line_shape ();
 void Init_reflex_rect_shape ();
 void Init_reflex_ellipse_shape ();
 
+void Init_reflex_pin ();
+void Init_reflex_constraint ();
+void Init_reflex_snap_constraint ();
+void Init_reflex_link_constraint ();
+void Init_reflex_rail_constraint ();
+void Init_reflex_chase_constraint ();
+
 void Init_reflex_application ();
 void Init_reflex_screen ();
 void Init_reflex_window ();
@@ -86,6 +93,13 @@ Init_reflex_ext ()
 	Init_reflex_line_shape();
 	Init_reflex_rect_shape();
 	Init_reflex_ellipse_shape();
+
+	Init_reflex_pin();
+	Init_reflex_constraint();
+	Init_reflex_snap_constraint();
+	Init_reflex_link_constraint();
+	Init_reflex_rail_constraint();
+	Init_reflex_chase_constraint();
 
 	Init_reflex_application();
 	Init_reflex_screen();

--- a/reflex/ext/reflex/pin.cpp
+++ b/reflex/ext/reflex/pin.cpp
@@ -1,0 +1,167 @@
+#include "reflex/ruby/pin.h"
+
+
+#include <rays/ruby/point.h>
+#include "reflex/ruby/constraint.h"
+#include "reflex/ruby/view.h"
+#include "defs.h"
+
+
+RUCY_DEFINE_VALUE_OR_ARRAY_FROM_TO(REFLEX_EXPORT, Reflex::Pin)
+
+#define THIS  to<Reflex::Pin*>(self)
+
+#define CHECK RUCY_CHECK_OBJ(Reflex::Pin, self)
+
+
+static
+RUCY_DEF_ALLOC(alloc, klass)
+{
+	return new_type<Reflex::Pin>(klass);
+}
+RUCY_END
+
+static
+RUCY_DEFN(initialize)
+{
+	CHECK;
+	*THIS = to<Reflex::Pin>(argc, argv);
+}
+RUCY_END
+
+static
+RUCY_DEF1(initialize_copy, obj)
+{
+	CHECK;
+	*THIS = to<Reflex::Pin&>(obj);
+}
+RUCY_END
+
+static
+RUCY_DEFN(snap)
+{
+	CHECK;
+	return value(THIS->snap(to<Reflex::Pin>(argc, argv)));
+}
+RUCY_END
+
+static
+RUCY_DEFN(link)
+{
+	CHECK;
+	return value(THIS->link(to<Reflex::Pin>(argc, argv)));
+}
+RUCY_END
+
+static
+RUCY_DEFN(rail)
+{
+	CHECK;
+	return value(THIS->rail(to<Reflex::Pin>(argc, argv)));
+}
+RUCY_END
+
+static
+RUCY_DEFN(chase)
+{
+	CHECK;
+	return value(THIS->chase(to<Reflex::Pin>(argc, argv)));
+}
+RUCY_END
+
+static
+RUCY_DEF0(get_view)
+{
+	CHECK;
+	return value(THIS->view());
+}
+RUCY_END
+
+static
+RUCY_DEF0(get_position)
+{
+	CHECK;
+	const Rays::Point* pos = THIS->position();
+	return pos ? value(*pos) : nil();
+}
+RUCY_END
+
+
+static Class cPin;
+
+void
+Init_reflex_pin ()
+{
+	Module mReflex = define_module("Reflex");
+
+	cPin = mReflex.define_class("Pin");
+	cPin.define_alloc_func(alloc);
+	cPin.define_private_method("initialize",      initialize);
+	cPin.define_private_method("initialize_copy", initialize_copy);
+	cPin.define_private_method("snap!",  snap);
+	cPin.define_private_method("link!",  link);
+	cPin.define_private_method("rail!",  rail);
+	cPin.define_private_method("chase!", chase);
+	cPin.define_method("view",     get_view);
+	cPin.define_method("position", get_position);
+}
+
+
+namespace Rucy
+{
+
+
+	template <> REFLEX_EXPORT Reflex::Pin
+	value_to<Reflex::Pin> (int argc, const Value* argv, bool convert)
+	{
+		if (argc == 1 && argv->is_array())
+		{
+			argc = argv->size();
+			argv = argv->as_array();
+		}
+
+		assert(argc == 0 || (argc > 0 && argv));
+
+		if (convert)
+		{
+			if (argc == 0 || argv->is_nil())
+				return Reflex::Pin();
+
+			if (argv->is_a(Reflex::view_class()))
+			{
+				Reflex::View* view = value_to<Reflex::View*>(*argv);
+				argc -= 1;
+				argv += 1;
+
+				if (argc == 0)
+					return Reflex::Pin(view);
+				else
+					return Reflex::Pin(view, value_to<Rays::Point>(argc, argv, convert));
+			}
+
+			if (!argv->is_a(Reflex::pin_class()))
+				return Reflex::Pin(value_to<Rays::Point>(argc, argv, convert));
+		}
+
+		if (argc != 1)
+			argument_error(__FILE__, __LINE__);
+
+		return value_to<Reflex::Pin&>(*argv, convert);
+	}
+
+
+}// Rucy
+
+
+namespace Reflex
+{
+
+
+	Class
+	pin_class ()
+	{
+		return cPin;
+	}
+
+
+}// Reflex

--- a/reflex/ext/reflex/rail_constraint.cpp
+++ b/reflex/ext/reflex/rail_constraint.cpp
@@ -1,0 +1,151 @@
+#include "reflex/ruby/constraint.h"
+
+
+#include <rays/ruby/point.h>
+#include "reflex/exception.h"
+#include "defs.h"
+
+
+RUCY_DEFINE_WRAPPER_VALUE_FROM_TO(REFLEX_EXPORT, Reflex::RailConstraint)
+
+#define THIS  to<Reflex::RailConstraint*>(self)
+
+#define CHECK RUCY_CHECK_OBJ(Reflex::RailConstraint, self)
+
+
+static
+RUCY_DEF_ALLOC(alloc, klass)
+{
+	Reflex::reflex_error(
+		__FILE__, __LINE__, "can not instantiate RailConstraint class");
+}
+RUCY_END
+
+static
+RUCY_DEFN(set_axis)
+{
+	CHECK;
+	THIS->set_axis(to<Rays::Point>(argc, argv));
+}
+RUCY_END
+
+static
+RUCY_DEF0(get_axis)
+{
+	CHECK;
+	return value(THIS->axis());
+}
+RUCY_END
+
+static
+RUCY_DEF1(set_rotate, state)
+{
+	CHECK;
+	THIS->set_rotate(to<bool>(state));
+}
+RUCY_END
+
+static
+RUCY_DEF0(can_rotate)
+{
+	CHECK;
+	return value(THIS->can_rotate());
+}
+RUCY_END
+
+static
+RUCY_DEF2(set_range, min, max)
+{
+	CHECK;
+	THIS->set_range(to<coord>(min), to<coord>(max));
+}
+RUCY_END
+
+static
+RUCY_DEF0(clear_range)
+{
+	CHECK;
+	THIS->clear_range();
+}
+RUCY_END
+
+static
+RUCY_DEF0(range_min)
+{
+	CHECK;
+	return value(THIS->range_min());
+}
+RUCY_END
+
+static
+RUCY_DEF0(range_max)
+{
+	CHECK;
+	return value(THIS->range_max());
+}
+RUCY_END
+
+static
+RUCY_DEF0(has_range)
+{
+	CHECK;
+	return value(THIS->has_range());
+}
+RUCY_END
+
+static
+RUCY_DEF1(set_motor, speed)
+{
+	CHECK;
+	if (speed.is_nil())
+		THIS->clear_motor();
+	else
+		THIS->set_motor(to<float>(speed));
+}
+RUCY_END
+
+static
+RUCY_DEF0(get_motor)
+{
+	CHECK;
+	return THIS->has_motor() ? value(THIS->motor()) : nil();
+}
+RUCY_END
+
+
+static Class cRailConstraint;
+
+void
+Init_reflex_rail_constraint ()
+{
+	Module mReflex = define_module("Reflex");
+
+	cRailConstraint = mReflex.define_class(
+		"RailConstraint", Reflex::constraint_class());
+	cRailConstraint.define_alloc_func(alloc);
+	cRailConstraint.define_method("axis=", set_axis);
+	cRailConstraint.define_method("axis",  get_axis);
+	cRailConstraint.define_method("rotate=", set_rotate);
+	cRailConstraint.define_method("rotate?", can_rotate);
+	cRailConstraint.define_private_method(  "set_range!",   set_range);
+	cRailConstraint.define_private_method("clear_range!", clear_range);
+	cRailConstraint.define_private_method(      "range_min!",   range_min);
+	cRailConstraint.define_private_method(      "range_max!",   range_max);
+	cRailConstraint.define_private_method(  "has_range!",   has_range);
+	cRailConstraint.define_method("motor=", set_motor);
+	cRailConstraint.define_method("motor",  get_motor);
+}
+
+
+namespace Reflex
+{
+
+
+	Class
+	rail_constraint_class ()
+	{
+		return cRailConstraint;
+	}
+
+
+}// Reflex

--- a/reflex/ext/reflex/snap_constraint.cpp
+++ b/reflex/ext/reflex/snap_constraint.cpp
@@ -1,0 +1,114 @@
+#include "reflex/ruby/constraint.h"
+
+
+#include "reflex/exception.h"
+#include "defs.h"
+
+
+RUCY_DEFINE_WRAPPER_VALUE_FROM_TO(REFLEX_EXPORT, Reflex::SnapConstraint)
+
+#define THIS  to<Reflex::SnapConstraint*>(self)
+
+#define CHECK RUCY_CHECK_OBJ(Reflex::SnapConstraint, self)
+
+
+static
+RUCY_DEF_ALLOC(alloc, klass)
+{
+	Reflex::reflex_error(
+		__FILE__, __LINE__, "can not instantiate SnapConstraint class");
+}
+RUCY_END
+
+static
+RUCY_DEF2(set_angle, min, max)
+{
+	CHECK;
+	THIS->set_angle(to<float>(min), to<float>(max));
+}
+RUCY_END
+
+static
+RUCY_DEF0(clear_angle)
+{
+	CHECK;
+	THIS->clear_angle();
+}
+RUCY_END
+
+static
+RUCY_DEF0(angle_min)
+{
+	CHECK;
+	return value(THIS->angle_min());
+}
+RUCY_END
+
+static
+RUCY_DEF0(angle_max)
+{
+	CHECK;
+	return value(THIS->angle_max());
+}
+RUCY_END
+
+static
+RUCY_DEF0(has_angle)
+{
+	CHECK;
+	return value(THIS->has_angle());
+}
+RUCY_END
+
+static
+RUCY_DEF1(set_motor, degree_per_second)
+{
+	CHECK;
+
+	if (degree_per_second.is_nil())
+		THIS->clear_motor();
+	else
+		THIS->set_motor(to<float>(degree_per_second));
+}
+RUCY_END
+
+static
+RUCY_DEF0(get_motor)
+{
+	CHECK;
+	return THIS->has_motor() ? value(THIS->motor()) : nil();
+}
+RUCY_END
+
+
+static Class cSnapConstraint;
+
+void
+Init_reflex_snap_constraint ()
+{
+	Module mReflex = define_module("Reflex");
+
+	cSnapConstraint = mReflex.define_class("SnapConstraint", Reflex::constraint_class());
+	cSnapConstraint.define_alloc_func(alloc);
+	cSnapConstraint.define_private_method(  "set_angle!",   set_angle);
+	cSnapConstraint.define_private_method("clear_angle!", clear_angle);
+	cSnapConstraint.define_private_method(      "angle_min!",   angle_min);
+	cSnapConstraint.define_private_method(      "angle_max!",   angle_max);
+	cSnapConstraint.define_private_method(  "has_angle!",   has_angle);
+	cSnapConstraint.define_method("motor=", set_motor);
+	cSnapConstraint.define_method("motor",  get_motor);
+}
+
+
+namespace Reflex
+{
+
+
+	Class
+	snap_constraint_class ()
+	{
+		return cSnapConstraint;
+	}
+
+
+}// Reflex

--- a/reflex/ext/reflex/view.cpp
+++ b/reflex/ext/reflex/view.cpp
@@ -10,6 +10,7 @@
 #include "reflex/ruby/timer.h"
 #include "reflex/ruby/style.h"
 #include "reflex/ruby/shape.h"
+#include "reflex/ruby/constraint.h"
 #include "reflex/ruby/filter.h"
 #include "reflex/ruby/window.h"
 #include "defs.h"
@@ -365,6 +366,27 @@ RUCY_DEF0(each_shape)
 	Value ret;
 	Reflex::View::shape_iterator end = THIS->shape_end();
 	for (Reflex::View::shape_iterator it = THIS->shape_begin(); it != end; ++it)
+		ret = rb_yield(value(it->get()));
+	return ret;
+}
+RUCY_END
+
+static
+RUCY_DEF0(clear_constraints)
+{
+	CHECK;
+	THIS->clear_constraints();
+	return self;
+}
+RUCY_END
+
+static
+RUCY_DEF0(each_constraint)
+{
+	CHECK;
+
+	Value ret;
+	for (auto it = THIS->constraint_begin(), end = THIS->constraint_end(); it != end; ++it)
 		ret = rb_yield(value(it->get()));
 	return ret;
 }
@@ -1286,6 +1308,9 @@ Init_reflex_view ()
 	cView.define_method( "clear_shapes", clear_shapes);
 	cView.define_method(  "find_shapes",  find_shapes);
 	cView.define_method(  "each_shape",   each_shape);
+
+	cView.define_method("clear_constraints", clear_constraints);
+	cView.define_method( "each_constraint",   each_constraint);
 
 	cView.define_method("filter=", set_filter);
 	cView.define_method("filter",  get_filter);

--- a/reflex/ext/reflex/view.cpp
+++ b/reflex/ext/reflex/view.cpp
@@ -381,6 +381,19 @@ RUCY_DEF0(clear_constraints)
 RUCY_END
 
 static
+RUCY_DEFN(find_constraints)
+{
+	CHECK;
+	check_arg_count(__FILE__, __LINE__, "View#find_constraints", argc, 1);
+
+	auto constraints =
+		THIS->find_constraints(to<Reflex::Selector>(argv[0])) |
+		std::views::transform([](auto& ref) {return value(ref.get());});
+	return array(constraints.begin(), constraints.end());
+}
+RUCY_END
+
+static
 RUCY_DEF0(each_constraint)
 {
 	CHECK;
@@ -1310,6 +1323,7 @@ Init_reflex_view ()
 	cView.define_method(  "each_shape",   each_shape);
 
 	cView.define_method("clear_constraints", clear_constraints);
+	cView.define_method( "find_constraints",  find_constraints);
 	cView.define_method( "each_constraint",   each_constraint);
 
 	cView.define_method("filter=", set_filter);

--- a/reflex/include/reflex.h
+++ b/reflex/include/reflex.h
@@ -15,6 +15,8 @@
 #include <reflex/style.h>
 #include <reflex/timer.h>
 #include <reflex/shape.h>
+#include <reflex/pin.h>
+#include <reflex/constraint.h>
 #include <reflex/filter.h>
 
 #include <reflex/application.h>

--- a/reflex/include/reflex/constraint.h
+++ b/reflex/include/reflex/constraint.h
@@ -1,0 +1,230 @@
+// -*- c++ -*-
+#pragma once
+#ifndef __REFLEX_CONSTRAINT_H__
+#define __REFLEX_CONSTRAINT_H__
+
+
+#include <xot/ref.h>
+#include <xot/pimpl.h>
+#include <rays/point.h>
+#include <reflex/defs.h>
+
+
+namespace Reflex
+{
+
+
+	class View;
+	class Pin;
+
+
+	class Constraint : public Xot::RefCountable<>
+	{
+
+		typedef Constraint This;
+
+		public:
+
+			typedef Xot::Ref<This> Ref;
+
+			virtual ~Constraint ();
+
+			virtual void remove ();
+
+			virtual const Pin& pin (size_t index) const;
+
+			virtual       View* view (size_t index);
+
+			virtual const View* view (size_t index) const;
+
+			virtual void set_spring (float hertz);
+
+			virtual float    spring () const;
+
+			virtual void set_damping (float ratio);
+
+			virtual float    damping () const;
+
+			virtual void set_collide (bool state);
+
+			virtual bool can_collide () const;
+
+			virtual bool is_removed () const;
+
+			virtual operator bool () const;
+
+			virtual bool operator ! () const;
+
+			struct Data;
+
+			Xot::PImpl<Data> self;
+
+		protected:
+
+			Constraint (Data* data);
+
+	};// Constraint
+
+
+	class SnapConstraint : public Constraint
+	{
+
+		typedef Constraint Super;
+
+		public:
+
+			virtual ~SnapConstraint ();
+
+			virtual void   set_angle (float min_degree, float max_degree);
+
+			virtual void clear_angle ();
+
+			virtual float      angle_min () const;
+
+			virtual float      angle_max () const;
+
+			virtual bool   has_angle () const;
+
+			virtual void   set_motor (float degree_per_second);
+
+			virtual void clear_motor ();
+
+			virtual float      motor () const;
+
+			virtual bool   has_motor () const;
+
+		protected:
+
+			SnapConstraint ();
+
+			friend class Pin;
+
+	};// SnapConstraint
+
+
+	class LinkConstraint : public Constraint
+	{
+
+		typedef Constraint Super;
+
+		public:
+
+			virtual ~LinkConstraint ();
+
+			virtual void      set_distance (coord distance);
+
+			virtual void    clear_distance ();
+
+			virtual coord         distance () const;
+
+			virtual bool      has_distance () const;
+
+			virtual coord current_distance () const;
+
+			virtual void   set_range (coord min, coord max);
+
+			virtual void clear_range ();
+
+			virtual coord      range_min () const;
+
+			virtual coord      range_max () const;
+
+			virtual bool   has_range () const;
+
+			virtual void   set_motor (coord pixel_per_second);
+
+			virtual void clear_motor ();
+
+			virtual coord      motor () const;
+
+			virtual bool   has_motor () const;
+
+		protected:
+
+			LinkConstraint ();
+
+			friend class Pin;
+
+	};// LinkConstraint
+
+
+	class RailConstraint : public Constraint
+	{
+
+		typedef Constraint Super;
+
+		public:
+
+			virtual ~RailConstraint ();
+
+			virtual void     set_axis (coord x, coord y);
+
+			virtual void     set_axis (const Point& direction);
+
+			virtual const Point& axis () const;
+
+			virtual void set_rotate (bool state);
+
+			virtual bool can_rotate () const;
+
+			virtual void   set_range (coord min, coord max);
+
+			virtual void clear_range ();
+
+			virtual coord      range_min () const;
+
+			virtual coord      range_max () const;
+
+			virtual bool   has_range () const;
+
+			virtual void   set_motor (float speed);
+
+			virtual void clear_motor ();
+
+			virtual float      motor () const;
+
+			virtual bool   has_motor () const;
+
+		protected:
+
+			RailConstraint ();
+
+			friend class Pin;
+
+	};// RailConstraint
+
+
+	class ChaseConstraint : public Constraint
+	{
+
+		typedef Constraint Super;
+
+		public:
+
+			virtual ~ChaseConstraint ();
+
+			virtual void   set_target (const Pin& target);
+
+			virtual const Pin& target () const;
+
+			virtual void   set_force (float max_force);
+
+			virtual void clear_force ();
+
+			virtual float      force () const;
+
+			virtual bool   has_force () const;
+
+		protected:
+
+			ChaseConstraint ();
+
+			friend class Pin;
+
+	};// ChaseConstraint
+
+
+}// Reflex
+
+
+#endif//EOH

--- a/reflex/include/reflex/constraint.h
+++ b/reflex/include/reflex/constraint.h
@@ -8,6 +8,7 @@
 #include <xot/pimpl.h>
 #include <rays/point.h>
 #include <reflex/defs.h>
+#include <reflex/selector.h>
 
 
 namespace Reflex
@@ -18,7 +19,7 @@ namespace Reflex
 	class Pin;
 
 
-	class Constraint : public Xot::RefCountable<>
+	class Constraint : public Xot::RefCountable<>, public HasSelector
 	{
 
 		typedef Constraint This;
@@ -62,6 +63,8 @@ namespace Reflex
 		protected:
 
 			Constraint (Data* data);
+
+			virtual SelectorPtr* get_selector_ptr () override;
 
 	};// Constraint
 

--- a/reflex/include/reflex/pin.h
+++ b/reflex/include/reflex/pin.h
@@ -1,0 +1,68 @@
+// -*- c++ -*-
+#pragma once
+#ifndef __REFLEX_PIN_H__
+#define __REFLEX_PIN_H__
+
+
+#include <xot/pimpl.h>
+#include <rays/point.h>
+#include <reflex/defs.h>
+
+
+namespace Reflex
+{
+
+
+	class View;
+	class SnapConstraint;
+	class LinkConstraint;
+	class RailConstraint;
+	class ChaseConstraint;
+
+
+	class Pin
+	{
+
+		public:
+
+			Pin ();
+
+			Pin (coord x, coord y);
+
+			Pin (const Point& position);
+
+			Pin (View* view);
+
+			Pin (View* view, coord x, coord y);
+
+			Pin (View* view, const Point& position);
+
+			SnapConstraint*  snap  (Pin target = Pin());
+
+			LinkConstraint*  link  (Pin target = Pin());
+
+			RailConstraint*  rail  (Pin target = Pin());
+
+			ChaseConstraint* chase (Pin target = Pin());
+
+			      View* view ();
+
+			const View* view () const;
+
+			const Point* position () const;
+
+			operator bool () const;
+
+			bool operator ! () const;
+
+			struct Data;
+
+			Xot::PSharedImpl<Data> self;
+
+	};// Pin
+
+
+}// Reflex
+
+
+#endif//EOH

--- a/reflex/include/reflex/ruby/constraint.h
+++ b/reflex/include/reflex/ruby/constraint.h
@@ -1,0 +1,90 @@
+// -*- c++ -*-
+#pragma once
+#ifndef __REFLEX_RUBY_CONSTRAINT_H__
+#define __REFLEX_RUBY_CONSTRAINT_H__
+
+
+#include <rucy/class.h>
+#include <rucy/extension.h>
+#include <reflex/constraint.h>
+
+
+RUCY_DECLARE_WRAPPER_VALUE_FROM_TO(REFLEX_EXPORT, Reflex::Constraint)
+
+RUCY_DECLARE_WRAPPER_VALUE_FROM_TO(REFLEX_EXPORT, Reflex::SnapConstraint)
+
+RUCY_DECLARE_WRAPPER_VALUE_FROM_TO(REFLEX_EXPORT, Reflex::LinkConstraint)
+
+RUCY_DECLARE_WRAPPER_VALUE_FROM_TO(REFLEX_EXPORT, Reflex::RailConstraint)
+
+RUCY_DECLARE_WRAPPER_VALUE_FROM_TO(REFLEX_EXPORT, Reflex::ChaseConstraint)
+
+
+namespace Reflex
+{
+
+
+	REFLEX_EXPORT Rucy::Class constraint_class ();
+	// class Reflex::Constraint
+
+	REFLEX_EXPORT Rucy::Class snap_constraint_class ();
+	// class Reflex::SnapConstraint
+
+	REFLEX_EXPORT Rucy::Class link_constraint_class ();
+	// class Reflex::LinkConstraint
+
+	REFLEX_EXPORT Rucy::Class rail_constraint_class ();
+	// class Reflex::RailConstraint
+
+	REFLEX_EXPORT Rucy::Class chase_constraint_class ();
+	// class Reflex::ChaseConstraint
+
+
+}// Reflex
+
+
+namespace Rucy
+{
+
+
+	template <> inline Class
+	get_ruby_class<Reflex::Constraint> ()
+	{
+		return Reflex::constraint_class();
+	}
+
+	template <> inline Class
+	get_ruby_class<Reflex::SnapConstraint> ()
+	{
+		return Reflex::snap_constraint_class();
+	}
+
+	template <> inline Class
+	get_ruby_class<Reflex::LinkConstraint> ()
+	{
+		return Reflex::link_constraint_class();
+	}
+
+	template <> inline Class
+	get_ruby_class<Reflex::RailConstraint> ()
+	{
+		return Reflex::rail_constraint_class();
+	}
+
+	template <> inline Class
+	get_ruby_class<Reflex::ChaseConstraint> ()
+	{
+		return Reflex::chase_constraint_class();
+	}
+
+	inline Value
+	value (Reflex::Constraint::Ref& ref, Value klass = Reflex::constraint_class())
+	{
+		return value(ref.get(), klass);
+	}
+
+
+}// Rucy
+
+
+#endif//EOH

--- a/reflex/include/reflex/ruby/pin.h
+++ b/reflex/include/reflex/ruby/pin.h
@@ -1,0 +1,40 @@
+// -*- c++ -*-
+#pragma once
+#ifndef __REFLEX_RUBY_PIN_H__
+#define __REFLEX_RUBY_PIN_H__
+
+
+#include <rucy/class.h>
+#include <rucy/extension.h>
+#include <reflex/pin.h>
+
+
+RUCY_DECLARE_VALUE_OR_ARRAY_FROM_TO(REFLEX_EXPORT, Reflex::Pin)
+
+
+namespace Reflex
+{
+
+
+	REFLEX_EXPORT Rucy::Class pin_class ();
+	// class Reflex::Pin
+
+
+}// Reflex
+
+
+namespace Rucy
+{
+
+
+	template <> inline Class
+	get_ruby_class<Reflex::Pin> ()
+	{
+		return Reflex::pin_class();
+	}
+
+
+}// Rucy
+
+
+#endif//EOH

--- a/reflex/include/reflex/view.h
+++ b/reflex/include/reflex/view.h
@@ -15,6 +15,7 @@
 #include <reflex/selector.h>
 #include <reflex/style.h>
 #include <reflex/shape.h>
+#include <reflex/constraint.h>
 #include <reflex/event.h>
 
 
@@ -38,23 +39,29 @@ namespace Reflex
 
 			typedef Xot::Ref<This> Ref;
 
-			typedef std::vector<Ref>        ChildList;
+			typedef std::vector<Ref>             ChildList;
 
-			typedef std::vector<Style>      StyleList;
+			typedef std::vector<Style>           StyleList;
 
-			typedef std::vector<Shape::Ref> ShapeList;
+			typedef std::vector<Shape::Ref>      ShapeList;
 
-			typedef ChildList::      iterator       child_iterator;
+			typedef std::vector<Constraint::Ref> ConstraintList;
 
-			typedef ChildList::const_iterator const_child_iterator;
+			typedef ChildList::           iterator            child_iterator;
 
-			typedef StyleList::      iterator       style_iterator;
+			typedef ChildList::     const_iterator      const_child_iterator;
 
-			typedef StyleList::const_iterator const_style_iterator;
+			typedef StyleList::           iterator            style_iterator;
 
-			typedef ShapeList::      iterator       shape_iterator;
+			typedef StyleList::     const_iterator      const_style_iterator;
 
-			typedef ShapeList::const_iterator const_shape_iterator;
+			typedef ShapeList::           iterator            shape_iterator;
+
+			typedef ShapeList::     const_iterator      const_shape_iterator;
+
+			typedef ConstraintList::      iterator       constraint_iterator;
+
+			typedef ConstraintList::const_iterator const_constraint_iterator;
 
 			enum Flag
 			{
@@ -186,6 +193,16 @@ namespace Reflex
 			virtual       shape_iterator shape_end ();
 
 			virtual const_shape_iterator shape_end () const;
+
+			virtual void                clear_constraints ();
+
+			virtual       constraint_iterator constraint_begin ();
+
+			virtual const_constraint_iterator constraint_begin () const;
+
+			virtual       constraint_iterator constraint_end ();
+
+			virtual const_constraint_iterator constraint_end () const;
 
 			virtual void      set_filter (Filter* filter);
 

--- a/reflex/include/reflex/view.h
+++ b/reflex/include/reflex/view.h
@@ -196,6 +196,8 @@ namespace Reflex
 
 			virtual void                clear_constraints ();
 
+			virtual ConstraintList       find_constraints (const Selector& selector) const;
+
 			virtual       constraint_iterator constraint_begin ();
 
 			virtual const_constraint_iterator constraint_begin () const;

--- a/reflex/lib/reflex.rb
+++ b/reflex/lib/reflex.rb
@@ -31,6 +31,13 @@ require 'reflex/line_shape'
 require 'reflex/rect_shape'
 require 'reflex/ellipse_shape'
 
+require 'reflex/pin'
+require 'reflex/constraint'
+require 'reflex/snap_constraint'
+require 'reflex/link_constraint'
+require 'reflex/rail_constraint'
+require 'reflex/chase_constraint'
+
 require 'reflex/update_event'
 require 'reflex/draw_event'
 require 'reflex/frame_event'

--- a/reflex/lib/reflex/chase_constraint.rb
+++ b/reflex/lib/reflex/chase_constraint.rb
@@ -1,0 +1,15 @@
+require 'reflex/ext'
+require 'reflex/constraint'
+
+
+module Reflex
+
+
+  class ChaseConstraint < Constraint
+
+    universal_accessor :target, :force
+
+  end# ChaseConstraint
+
+
+end# Reflex

--- a/reflex/lib/reflex/constraint.rb
+++ b/reflex/lib/reflex/constraint.rb
@@ -1,0 +1,26 @@
+require 'xot/setter'
+require 'xot/universal_accessor'
+require 'reflex/ext'
+
+
+module Reflex
+
+
+  class Constraint
+
+    include Xot::Setter
+
+    def pins()
+      [get_pin(0), get_pin(1)]
+    end
+
+    def views()
+      pins.map(&:view)
+    end
+
+    universal_accessor :spring, :damping, collide: {reader: :collide?}
+
+  end# Constraint
+
+
+end# Reflex

--- a/reflex/lib/reflex/constraint.rb
+++ b/reflex/lib/reflex/constraint.rb
@@ -1,6 +1,7 @@
 require 'xot/setter'
 require 'xot/universal_accessor'
 require 'reflex/ext'
+require 'reflex/helper'
 
 
 module Reflex
@@ -9,6 +10,7 @@ module Reflex
   class Constraint
 
     include Xot::Setter
+    include HasTags
 
     def pins()
       [get_pin(0), get_pin(1)]
@@ -18,7 +20,8 @@ module Reflex
       pins.map(&:view)
     end
 
-    universal_accessor :spring, :damping, collide: {reader: :collide?}
+    universal_accessor :name, :selector,
+      :spring, :damping, collide: {reader: :collide?}
 
   end# Constraint
 

--- a/reflex/lib/reflex/link_constraint.rb
+++ b/reflex/lib/reflex/link_constraint.rb
@@ -1,0 +1,31 @@
+require 'reflex/ext'
+require 'reflex/constraint'
+
+
+module Reflex
+
+
+  class LinkConstraint < Constraint
+
+    def range=(range)
+      case range
+      when nil     then clear_range!
+      when Range   then set_range! range.begin, range.end
+      when Numeric then set_range! range,       range
+      else raise ArgumentError, "invalid range: #{range.inspect}"
+      end
+    end
+
+    def range()
+      has_range! ? Range.new(range_min!, range_max!) : nil
+    end
+
+    universal_accessor :distance, :range, :motor
+
+    alias dist= distance=
+    alias dist  distance
+
+  end# LinkConstraint
+
+
+end# Reflex

--- a/reflex/lib/reflex/pin.rb
+++ b/reflex/lib/reflex/pin.rb
@@ -1,0 +1,39 @@
+require 'xot/block_util'
+require 'reflex/ext'
+
+
+module Reflex
+
+
+  class Pin
+
+    def snap(*args, **options, &block)
+      setup__ snap!(*args), options, block
+    end
+
+    def link(*args, **options, &block)
+      setup__ link!(*args), options, block
+    end
+
+    def rail(*args, **options, &block)
+      setup__ rail!(*args), options, block
+    end
+
+    def chase(*args, **options, &block)
+      setup__ chase!(*args), options, block
+    end
+
+    alias pos position
+
+    private
+
+    def setup__(constraint, options, block)
+      constraint.set options unless options.empty?
+      Xot::BlockUtil.instance_eval_or_block_call constraint, &block if block
+      constraint
+    end
+
+  end# Pin
+
+
+end# Reflex

--- a/reflex/lib/reflex/rail_constraint.rb
+++ b/reflex/lib/reflex/rail_constraint.rb
@@ -1,0 +1,28 @@
+require 'reflex/ext'
+require 'reflex/constraint'
+
+
+module Reflex
+
+
+  class RailConstraint < Constraint
+
+    def range=(range)
+      case range
+      when nil     then clear_range!
+      when Range   then set_range! range.begin, range.end
+      when Numeric then set_range! range,       range
+      else raise ArgumentError, "invalid range: #{range.inspect}"
+      end
+    end
+
+    def range()
+      has_range! ? Range.new(range_min!, range_max!) : nil
+    end
+
+    universal_accessor :axis, :range, :motor, rotate: {reader: :rotate?}
+
+  end# RailConstraint
+
+
+end# Reflex

--- a/reflex/lib/reflex/snap_constraint.rb
+++ b/reflex/lib/reflex/snap_constraint.rb
@@ -1,0 +1,28 @@
+require 'reflex/ext'
+require 'reflex/constraint'
+
+
+module Reflex
+
+
+  class SnapConstraint < Constraint
+
+    def angle=(angle)
+      case angle
+      when nil     then clear_angle!
+      when Range   then set_angle! angle.begin, angle.end
+      when Numeric then set_angle! angle,       angle
+      else raise ArgumentError, "invalid angle: #{angle.inspect}"
+      end
+    end
+
+    def angle()
+      has_angle! ? Range.new(angle_min!, angle_max!) : nil
+    end
+
+    universal_accessor :angle, :motor
+
+  end# SnapConstraint
+
+
+end# Reflex

--- a/reflex/lib/reflex/view.rb
+++ b/reflex/lib/reflex/view.rb
@@ -99,6 +99,30 @@ module Reflex
       to_enum :each_shape
     end
 
+    def pin(*args)
+      Pin.new self, *args
+    end
+
+    def snap(*args, **options, &block)
+      pin.snap(*args, **options, &block)
+    end
+
+    def link(*args, **options, &block)
+      pin.link(*args, **options, &block)
+    end
+
+    def rail(*args, **options, &block)
+      pin.rail(*args, **options, &block)
+    end
+
+    def chase(*args, **options, &block)
+      pin.chase(*args, **options, &block)
+    end
+
+    def constraints()
+      to_enum :each_constraint
+    end
+
     def capturing?(*args)
       args, cap = args.flatten, capture
       if args.empty?

--- a/reflex/samples/constraint.rb
+++ b/reflex/samples/constraint.rb
@@ -1,0 +1,129 @@
+%w[xot rays reflex]
+  .map  {|s| File.expand_path "../../#{s}/lib", __dir__}
+  .each {|s| $:.unshift s if !$:.include?(s) && File.directory?(s)}
+
+require 'reflex'
+
+
+Reflex.start name: "Constraint" do |app|
+  Reflex::Window.show title: app.name, frame: [100, 100, 500, 500] do
+    gravity 0, 9.8 * meter
+    #debug   true
+
+    ball = -> x, y, size_ = 30, color = :red do
+      Reflex::View.new {
+        pos        x, y
+        size       size_
+        background color
+        dynamic    true
+        shape      Reflex::EllipseShape.new(density: 1)
+      }
+    end
+
+    anchor = -> x, y do
+      Reflex::View.new {
+        pos        x, y
+        size       10
+        background :darkgray
+        static     true
+      }
+    end
+
+    # pendulum: snap the hanging ball to the anchor center
+    pivot  = add anchor.call(100, 100)
+    weight = add ball.call(160, 100, 30, :orange)
+    pivot.snap weight
+
+    # motored arm: snap with angle range and a motor
+    hinge = add anchor.call(250, 100)
+    arm   = add ball.call(250, 140, 20, :peach)
+    hinge.snap arm, angle: -60..60, motor: 90
+
+    # ground: a bumpy line the car drives over
+    ground = [[0, 480], [70, 465], [140, 482], [210, 462],
+              [280, 480], [350, 465], [420, 482], [500, 470]]
+    add Reflex::View.new {
+      pos 0, 0; size 500, 500
+      static true
+      shape  Reflex::LineShape.new.tap {|line| line.add_points(*ground.flatten)}
+    }
+
+    # car: each wheel rails onto the body with a suspension spring and a
+    # drive motor, so it rolls over the bumpy ground
+    body   = add Reflex::View.new {
+      pos 50, 400; size 70, 16
+      background :white
+      dynamic    true
+      shape      Reflex::RectShape.new(density: 1)
+    }
+    wheels, axles = [], []
+    [14, 56].each do |x|
+      wheel = add ball.call(40 + x, 415, 20, :gray)
+      wheels << wheel
+      axles  << wheel.pin(10, 10).rail(body.pin(x, 20),
+        axis: [0, 1], rotate: true, spring: 6, damping: 0.7, motor: 360)
+    end
+
+    # reverse the drive each time the car reaches a wall. a wheel or a body
+    # corner may touch first, so watch them all; the side check ignores the
+    # second touch when two parts hit the same wall together.
+    edge      = wall
+    mid, side = body.parent.center.x, nil
+    reverse   = lambda do |e|
+      left = body.center.x < mid
+      next if e.view != edge || left == side
+      side = left
+      axles.each {|a| a.motor = -a.motor}
+    end
+    [body, *wheels].each {|part| part.on :contact_begin, &reverse}
+
+    # spring chain: balls linked with springs
+    # (collide: true lets the nodes bump each other instead of overlapping)
+    top  = add anchor.call(400, 50)
+    prev = top
+    4.times do |i|
+      node = add ball.call(400, 90 + i * 40, 20, :green)
+      node.link prev, spring: 4, damping: 0.5, collide: true
+      prev = node
+    end
+
+    # chaser: follows the pendulum weight with a soft spring
+    chaser = add ball.call(100, 400, 25, :blue)
+    chaser.gravity_scale = 0
+    chaser.sensor        = true# do not bump the pendulum
+    chaser.chase weight, spring: 2, damping: 1
+
+    # drag any ball with a chase constraint
+    drag = nil
+    on :pointer do |e|
+      case
+      when e.down?
+        # hit test in each view's local space to respect rotation, and
+        # prefer the topmost (= last added) view
+        hit = children.to_a.reverse.find do |c|
+          next false unless c.dynamic?
+          p = c.from_parent e.pos
+          p.x.between?(0, c.frame.w) && p.y.between?(0, c.frame.h)
+        end
+        # grab the view at the clicked point, not at its center
+        drag = hit.pin(hit.from_parent e.pos).chase e.pos,
+          spring: 5, damping: 0.7 if hit
+      when e.drag?
+        drag.target = e.pos if drag
+      when e.up?
+        drag&.remove
+        drag = nil
+      end
+    end
+
+    after :on_draw do |e|
+      e.painter.push do
+        stroke :gray
+        ground.each_cons(2) {|a, b| line a[0], a[1], b[0], b[1]}
+        no_stroke
+        fill :white
+        text "#{e.fps.to_i} FPS - drag a ball to chase the pointer", 10, 10
+      end
+    end
+  end
+end

--- a/reflex/src/constraint.cpp
+++ b/reflex/src/constraint.cpp
@@ -1,0 +1,1352 @@
+#include "constraint.h"
+
+
+#include <box2d/box2d.h>
+#include "reflex/pin.h"
+#include "reflex/exception.h"
+#include "view.h"
+#include "body.h"
+#include "world.h"
+
+
+namespace Reflex
+{
+
+
+	static constexpr float DEFAULT_DAMPING      = 0.7f;
+
+	static constexpr float DEFAULT_CHASE_SPRING = 5;
+
+	static constexpr float FORCE_PER_MASS       = 1000;
+
+
+	static float
+	default_max_force (b2BodyId body)
+	{
+		float mass = b2Body_GetMass(body);
+		return FORCE_PER_MASS * (mass > 0 ? mass : 1);
+	}
+
+	static Point
+	view_center (const View* view)
+	{
+		return view ? view->frame().size() / 2 : Point(0);
+	}
+
+	static float
+	relative_angle (b2BodyId body0, b2BodyId body1)
+	{
+		return
+			b2Rot_GetAngle(b2Body_GetRotation(body0)) -
+			b2Rot_GetAngle(b2Body_GetRotation(body1));
+	}
+
+
+	struct Constraint::Data
+	{
+
+		Pin pins[2];
+
+		b2JointId b2joint  = b2_nullJointId;
+
+		World* world       = NULL;
+
+		float spring       = 0;
+
+		float damping      = DEFAULT_DAMPING;
+
+		bool collide       = false;
+
+		bool removed       = false;
+
+		bool resolved      = false;
+
+		float resolved_ppm = 0;
+
+		b2Vec2 anchor0     = {0, 0};
+
+		b2Vec2 anchor1     = {0, 0};
+
+		float ref_angle    = 0;
+
+		virtual ~Data ()
+		{
+		}
+
+		virtual b2JointId create_joint (
+			b2WorldId world, b2BodyId body0, b2BodyId body1, float ppm) = 0;
+
+		virtual void apply_params (float ppm) = 0;
+
+		virtual void on_world_update (float ppm)
+		{
+		}
+
+		bool is_valid () const
+		{
+			return b2Joint_IsValid(b2joint);
+		}
+
+		float ppm () const
+		{
+			assert(world);
+			return world->meter2pixel();
+		}
+
+		void resolve_anchors (b2BodyId body0, b2BodyId body1, float ppm)
+		{
+			if (resolved)
+				return rescale_resolved_anchors(ppm);
+
+			const Point* pos0 = pins[0].position();
+			const Point* pos1 = pins[1].position();
+
+			if (pos0 && pos1)
+			{
+				anchor0 = to_b2vec2(*pos0, ppm);
+				anchor1 = to_b2vec2(*pos1, ppm);
+			}
+			else if (pos1)
+			{
+				anchor1 = to_b2vec2(*pos1, ppm);
+				anchor0 = b2Body_GetLocalPoint(body0, b2Body_GetWorldPoint(body1, anchor1));
+			}
+			else
+			{
+				anchor0 = to_b2vec2(pos0 ? *pos0 : view_center(pins[0].view()), ppm);
+				anchor1 = b2Body_GetLocalPoint(body1, b2Body_GetWorldPoint(body0, anchor0));
+			}
+
+			ref_angle    = relative_angle(body0, body1);
+			resolved     = true;
+			resolved_ppm = ppm;
+			write_back_resolved_pins();
+		}
+
+		void rescale_resolved_anchors (float ppm)
+		{
+			// the anchors cache the pinned positions in meters, so moving to
+			// a world with another pixels-per-meter only needs unit rescaling,
+			// never a re-derivation
+
+			if (resolved_ppm == ppm) return;
+
+			anchor0      = to_b2vec2(*pins[0].position(), ppm);
+			anchor1      = to_b2vec2(*pins[1].position(), ppm);
+			resolved_ppm = ppm;
+		}
+
+		void write_back_resolved_pins ()
+		{
+			if (!pins[0].position())
+				pins[0] = Pin(pins[0].view(), to_point(anchor0, resolved_ppm));
+			if (!pins[1].position())
+				pins[1] = Pin(pins[1].view(), to_point(anchor1, resolved_ppm));
+		}
+
+		void update_params ()
+		{
+			if (!is_valid() || !world) return;
+
+			b2Joint_SetCollideConnected(b2joint, collide);
+			apply_params(ppm());
+			b2Joint_WakeBodies(b2joint);
+		}
+
+	};// Constraint::Data
+
+
+	static void
+	reactivate_constraint (Constraint* constraint)
+	{
+		assert(constraint);
+
+		if (!constraint->self->is_valid()) return;
+
+		Constraint_deactivate(constraint);
+		Constraint_activate(constraint);
+	}
+
+	b2JointId
+	Constraint_get_id (const Constraint* constraint)
+	{
+		return constraint ? constraint->self->b2joint : b2_nullJointId;
+	}
+
+	void
+	Constraint_set_pins (
+		Constraint* constraint,
+		View* view0, const Point* position0,
+		View* view1, const Point* position1)
+	{
+		if (!constraint || !view0)
+			argument_error(__FILE__, __LINE__);
+
+		if (view0 == view1)
+			argument_error(__FILE__, __LINE__, "can not constrain a view to itself");
+
+		Constraint::Data* self = constraint->self.get();
+
+		if (self->pins[0].view())
+			invalid_state_error(__FILE__, __LINE__, "constraint already has pins");
+
+		self->pins[0] = position0 ? Pin(view0, *position0) : Pin(view0);
+		self->pins[1] = position1 ? Pin(view1, *position1) : Pin(view1);
+	}
+
+	static bool
+	get_view_body_and_world (b2BodyId* pid, World** ppworld, View* view)
+	{
+		if (!view)
+			return false;
+
+		Body* body = View_get_body(view);
+		if (!body || Body_is_temporary(*body))
+			return false;
+
+		World* world = Body_get_world(body);
+		if (!world)
+			return false;
+
+		*ppworld = world;
+		*pid     = Body_get_id(body);
+		return true;
+	}
+
+	bool
+	Constraint_activate (Constraint* constraint)
+	{
+		if (!constraint)
+			argument_error(__FILE__, __LINE__);
+
+		Constraint::Data* self = constraint->self.get();
+
+		if (self->removed || self->is_valid())
+			return false;
+
+		b2BodyId id0 = b2_nullBodyId;
+		b2BodyId id1 = b2_nullBodyId;
+
+		World* world0 = NULL;
+		if (!get_view_body_and_world(&id0, &world0, self->pins[0].view()))
+			return false;
+
+		View* view1 = self->pins[1].view();
+		if (view1)
+		{
+			World* world1 = NULL;
+			if (!get_view_body_and_world(&id1, &world1, view1))
+				return false;
+
+			if (world1 != world0)
+				return false;
+		}
+		else
+			id1 = Body_get_id(World_get_ground(world0));
+
+		if (World_is_stepping(world0))
+			physics_error(__FILE__, __LINE__, "world is stepping now");
+
+		b2JointId joint =
+			self->create_joint(World_get_id(world0), id0, id1, world0->meter2pixel());
+		if (!b2Joint_IsValid(joint))
+			physics_error(__FILE__, __LINE__);
+
+		self->b2joint = joint;
+		self->world   = world0;
+		World_add_constraint(world0, constraint);
+		return true;
+	}
+
+	void
+	Constraint_deactivate (Constraint* constraint)
+	{
+		if (!constraint)
+			argument_error(__FILE__, __LINE__);
+
+		Constraint::Data* self = constraint->self.get();
+
+		if (self->world)
+		{
+			if (self->is_valid())
+			{
+				if (World_is_stepping(self->world))
+					physics_error(__FILE__, __LINE__, "world is stepping now");
+
+				b2DestroyJoint(self->b2joint);
+			}
+			World_remove_constraint(self->world, constraint);
+		}
+
+		self->b2joint = b2_nullJointId;
+		self->world   = NULL;
+	}
+
+	void
+	Constraint_sever (Constraint* constraint)
+	{
+		if (!constraint)
+			argument_error(__FILE__, __LINE__);
+
+		Constraint::Data* self = constraint->self.get();
+
+		if (self->removed) return;
+
+		Constraint::Ref guard(constraint);
+
+		Constraint_deactivate(constraint);
+		self->removed = true;
+
+		View* view0 = self->pins[0].view();
+		View* view1 = self->pins[1].view();
+		if (view0) View_remove_constraint(view0, constraint);
+		if (view1) View_remove_constraint(view1, constraint);
+	}
+
+	void
+	Constraint_on_world_destroyed (Constraint* constraint)
+	{
+		if (!constraint)
+			argument_error(__FILE__, __LINE__);
+
+		Constraint::Data* self = constraint->self.get();
+
+		self->b2joint = b2_nullJointId;
+		self->world   = NULL;
+	}
+
+	void
+	Constraint_on_world_update (Constraint* constraint)
+	{
+		if (!constraint)
+			argument_error(__FILE__, __LINE__);
+
+		Constraint::Data* self = constraint->self.get();
+		if (!self->world) return;
+
+		self->on_world_update(self->ppm());
+	}
+
+	bool
+	Constraint_has_world_mismatch (const Constraint* constraint)
+	{
+		if (!constraint)
+			argument_error(__FILE__, __LINE__);
+
+		const Constraint::Data* self = constraint->self.get();
+
+		const View* view0 = self->pins[0].view();
+		const View* view1 = self->pins[1].view();
+		if (!view0 || !view1) return false;
+
+		const Body* body0 = View_get_body(view0);
+		const Body* body1 = View_get_body(view1);
+		if (!body0 || Body_is_temporary(*body0)) return false;
+		if (!body1 || Body_is_temporary(*body1)) return false;
+
+		return Body_get_world(body0) != Body_get_world(body1);
+	}
+
+
+	Constraint::Constraint (Data* data)
+	:	self(data)
+	{
+	}
+
+	Constraint::~Constraint ()
+	{
+		Constraint_deactivate(this);
+	}
+
+	void
+	Constraint::remove ()
+	{
+		Constraint_sever(this);
+	}
+
+	const Pin&
+	Constraint::pin (size_t index) const
+	{
+		if (index > 1)
+			argument_error(__FILE__, __LINE__);
+
+		return self->pins[index];
+	}
+
+	View*
+	Constraint::view (size_t index)
+	{
+		if (index > 1)
+			argument_error(__FILE__, __LINE__);
+
+		return self->pins[index].view();
+	}
+
+	const View*
+	Constraint::view (size_t index) const
+	{
+		return const_cast<Constraint*>(this)->view(index);
+	}
+
+	void
+	Constraint::set_spring (float hertz)
+	{
+		if (hertz < 0)
+			argument_error(__FILE__, __LINE__);
+
+		self->spring = hertz;
+		self->update_params();
+	}
+
+	float
+	Constraint::spring () const
+	{
+		return self->spring;
+	}
+
+	void
+	Constraint::set_damping (float ratio)
+	{
+		if (ratio < 0)
+			argument_error(__FILE__, __LINE__);
+
+		self->damping = ratio;
+		self->update_params();
+	}
+
+	float
+	Constraint::damping () const
+	{
+		return self->damping;
+	}
+
+	void
+	Constraint::set_collide (bool state)
+	{
+		self->collide = state;
+		self->update_params();
+	}
+
+	bool
+	Constraint::can_collide () const
+	{
+		return self->collide;
+	}
+
+	bool
+	Constraint::is_removed () const
+	{
+		return self->removed;
+	}
+
+	Constraint::operator bool () const
+	{
+		return self->is_valid();
+	}
+
+	bool
+	Constraint::operator ! () const
+	{
+		return !operator bool();
+	}
+
+
+	struct SnapConstraintData : public Constraint::Data
+	{
+
+		bool  has_angle   = false;
+
+		float angle_min   = 0;
+
+		float angle_max   = 0;
+
+		bool  has_motor   = false;
+
+		float motor_speed = 0;
+
+		bool use_weld () const
+		{
+			return has_angle && angle_min == angle_max;
+		}
+
+		b2JointId create_joint (
+			b2WorldId world, b2BodyId body0, b2BodyId body1, float ppm) override
+		{
+			resolve_anchors(body0, body1, ppm);
+
+			// the declaring side goes to bodyB because the mouse joint
+			// assumes bodyA is static
+			if (use_weld())
+			{
+				b2WeldJointDef def      = b2DefaultWeldJointDef();
+				def.bodyIdA             = body1;
+				def.bodyIdB             = body0;
+				def.localAnchorA        = anchor1;
+				def.localAnchorB        = anchor0;
+				def.referenceAngle      = ref_angle + Xot::deg2rad(angle_min);
+				def.linearHertz         = spring;
+				def.angularHertz        = spring;
+				def.linearDampingRatio  = damping;
+				def.angularDampingRatio = damping;
+				def.collideConnected    = collide;
+				return b2CreateWeldJoint(world, &def);
+			}
+			else
+			{
+				b2RevoluteJointDef def = b2DefaultRevoluteJointDef();
+				def.bodyIdA            = body1;
+				def.bodyIdB            = body0;
+				def.localAnchorA       = anchor1;
+				def.localAnchorB       = anchor0;
+				def.referenceAngle     = ref_angle;
+				def.enableSpring       = spring > 0;
+				def.hertz              = spring;
+				def.dampingRatio       = damping;
+				def.enableLimit        = has_angle;
+				def.lowerAngle         = Xot::deg2rad(angle_min);
+				def.upperAngle         = Xot::deg2rad(angle_max);
+				def.enableMotor        = has_motor;
+				def.motorSpeed         = Xot::deg2rad(motor_speed);
+				def.maxMotorTorque     = default_max_force(body0);
+				def.collideConnected   = collide;
+				return b2CreateRevoluteJoint(world, &def);
+			}
+		}
+
+		void apply_params (float ppm) override
+		{
+			if (b2Joint_GetType(b2joint) == b2_weldJoint)
+			{
+				float min = Xot::deg2rad(angle_min);
+				b2Joint_SetReferenceAngle(         b2joint, ref_angle + min);
+				b2WeldJoint_SetLinearHertz(        b2joint, spring);
+				b2WeldJoint_SetAngularHertz(       b2joint, spring);
+				b2WeldJoint_SetLinearDampingRatio( b2joint, damping);
+				b2WeldJoint_SetAngularDampingRatio(b2joint, damping);
+			}
+			else
+			{
+				b2RevoluteJoint_EnableSpring(         b2joint, spring > 0);
+				b2RevoluteJoint_SetSpringHertz(       b2joint, spring);
+				b2RevoluteJoint_SetSpringDampingRatio(b2joint, damping);
+				b2RevoluteJoint_EnableLimit(          b2joint, has_angle);
+				if (has_angle)
+				{
+					float min = Xot::deg2rad(angle_min), max = Xot::deg2rad(angle_max);
+					b2RevoluteJoint_SetLimits(          b2joint, min, max);
+				}
+				b2RevoluteJoint_EnableMotor(          b2joint, has_motor);
+				b2RevoluteJoint_SetMotorSpeed(        b2joint, Xot::deg2rad(motor_speed));
+			}
+		}
+
+	};// SnapConstraintData
+
+
+	static SnapConstraintData&
+	get_data (SnapConstraint& constraint)
+	{
+		return (SnapConstraintData&) *constraint.self;
+	}
+
+	static const SnapConstraintData&
+	get_data (const SnapConstraint& constraint)
+	{
+		return get_data(const_cast<SnapConstraint&>(constraint));
+	}
+
+
+	SnapConstraint::SnapConstraint ()
+	:	Super(new SnapConstraintData)
+	{
+	}
+
+	SnapConstraint::~SnapConstraint ()
+	{
+	}
+
+	static void
+	update_angle (SnapConstraint* c, bool has_angle, float min, float max)
+	{
+		if (min > max)
+			argument_error(__FILE__, __LINE__);
+
+		SnapConstraintData& self = get_data(*c);
+
+		bool weld      = self.use_weld();
+		self.has_angle = has_angle;
+		self.angle_min = min;
+		self.angle_max = max;
+
+		if (self.is_valid() && weld != self.use_weld())
+			reactivate_constraint(c);
+		else
+			self.update_params();
+	}
+
+	void
+	SnapConstraint::set_angle (float min_degree, float max_degree)
+	{
+		update_angle(this, true, min_degree, max_degree);
+	}
+
+	void
+	SnapConstraint::clear_angle ()
+	{
+		update_angle(this, false, 0, 0);
+	}
+
+	float
+	SnapConstraint::angle_min () const
+	{
+		return get_data(*this).angle_min;
+	}
+
+	float
+	SnapConstraint::angle_max () const
+	{
+		return get_data(*this).angle_max;
+	}
+
+	bool
+	SnapConstraint::has_angle () const
+	{
+		return get_data(*this).has_angle;
+	}
+
+	static void
+	update_motor (SnapConstraint* c, bool has_motor, float speed)
+	{
+		SnapConstraintData& self = get_data(*c);
+
+		self.has_motor   = has_motor;
+		self.motor_speed = speed;
+		self.update_params();
+	}
+
+	void
+	SnapConstraint::set_motor (float degree_per_second)
+	{
+		update_motor(this, true, degree_per_second);
+	}
+
+	void
+	SnapConstraint::clear_motor ()
+	{
+		update_motor(this, false, 0);
+	}
+
+	float
+	SnapConstraint::motor () const
+	{
+		return get_data(*this).motor_speed;
+	}
+
+	bool
+	SnapConstraint::has_motor () const
+	{
+		return get_data(*this).has_motor;
+	}
+
+
+	struct LinkConstraintData : public Constraint::Data
+	{
+
+		bool  has_distance = false;
+
+		coord distance     = 0;
+
+		float b2distance   = 0;
+
+		bool  has_range    = false;
+
+		coord range_min    = 0;
+
+		coord range_max    = 0;
+
+		bool  has_motor    = false;
+
+		coord motor_speed  = 0;
+
+		b2JointId create_joint (
+			b2WorldId world, b2BodyId body0, b2BodyId body1, float ppm) override
+		{
+			resolve_link_anchors(body0, body1, ppm);
+
+			// the declaring side goes to bodyB because the mouse joint
+			// assumes bodyA is static
+			b2DistanceJointDef def = b2DefaultDistanceJointDef();
+			def.bodyIdA            = body1;
+			def.bodyIdB            = body0;
+			def.localAnchorA       = anchor1;
+			def.localAnchorB       = anchor0;
+			def.length             = b2distance;
+			def.enableSpring       = spring > 0;
+			def.hertz              = spring;
+			def.dampingRatio       = damping;
+			def.enableLimit        = has_range;
+			def.minLength          = to_b2coord(range_min, ppm);
+			def.maxLength          = to_b2coord(range_max, ppm);
+			def.enableMotor        = has_motor;
+			def.motorSpeed         = to_b2coord(motor_speed, ppm);
+			def.maxMotorForce      = default_max_force(body0);
+			def.collideConnected   = collide;
+			return b2CreateDistanceJoint(world, &def);
+		}
+
+		void resolve_link_anchors (b2BodyId body0, b2BodyId body1, float ppm)
+		{
+			// unlike coincidence type constraints, unspecified link anchors
+			// default to the view centers because the relation to be kept is
+			// the distance, not the anchor placement
+
+			if (resolved)
+			{
+				if (has_distance)
+					b2distance = to_b2coord(distance, ppm);
+				else if (resolved_ppm != ppm)
+					b2distance = to_b2coord(to_coord(b2distance, resolved_ppm), ppm);
+
+				return rescale_resolved_anchors(ppm);
+			}
+
+			const Point* pos0 = pins[0].position();
+			const Point* pos1 = pins[1].position();
+
+			anchor0 = to_b2vec2(pos0 ? *pos0 : view_center(pins[0].view()), ppm);
+			if (pos1)
+				anchor1 = to_b2vec2(*pos1, ppm);
+			else if (pins[1].view())
+				anchor1 = to_b2vec2(view_center(pins[1].view()), ppm);
+			else
+				anchor1 = b2Body_GetLocalPoint(body1, b2Body_GetWorldPoint(body0, anchor0));
+
+			ref_angle    = relative_angle(body0, body1);
+			resolved     = true;
+			resolved_ppm = ppm;
+			b2distance   = has_distance
+				?	to_b2coord(distance, ppm)
+				:	b2Distance(b2Body_GetWorldPoint(body0, anchor0), b2Body_GetWorldPoint(body1, anchor1));
+
+			write_back_resolved_pins();
+		}
+
+		void apply_params (float ppm) override
+		{
+			if (has_distance)
+				b2DistanceJoint_SetLength(          b2joint, to_b2coord(distance, ppm));
+			b2DistanceJoint_EnableSpring(         b2joint, spring > 0);
+			b2DistanceJoint_SetSpringHertz(       b2joint, spring);
+			b2DistanceJoint_SetSpringDampingRatio(b2joint, damping);
+			b2DistanceJoint_EnableLimit(          b2joint, has_range);
+			if (has_range)
+			{
+				float min = to_b2coord(range_min, ppm), max = to_b2coord(range_max, ppm);
+				b2DistanceJoint_SetLengthRange(     b2joint, min, max);
+			}
+			b2DistanceJoint_EnableMotor(          b2joint, has_motor);
+			b2DistanceJoint_SetMotorSpeed(        b2joint, to_b2coord(motor_speed, ppm));
+		}
+
+	};// LinkConstraintData
+
+
+	static LinkConstraintData&
+	get_data (LinkConstraint& constraint)
+	{
+		return (LinkConstraintData&) *constraint.self;
+	}
+
+	static const LinkConstraintData&
+	get_data (const LinkConstraint& constraint)
+	{
+		return get_data(const_cast<LinkConstraint&>(constraint));
+	}
+
+
+	LinkConstraint::LinkConstraint ()
+	:	Super(new LinkConstraintData)
+	{
+	}
+
+	LinkConstraint::~LinkConstraint ()
+	{
+	}
+
+	static void
+	update_distance (LinkConstraint* c, bool has_distance, coord distance)
+	{
+		if (distance < 0)
+			argument_error(__FILE__, __LINE__);
+
+		LinkConstraintData& self = get_data(*c);
+
+		self.has_distance = has_distance;
+		self.distance     = distance;
+		self.update_params();
+	}
+
+	void
+	LinkConstraint::set_distance (coord distance)
+	{
+		update_distance(this, true, distance);
+	}
+
+	void
+	LinkConstraint::clear_distance ()
+	{
+		update_distance(this, false, 0);
+	}
+
+	coord
+	LinkConstraint::distance () const
+	{
+		const LinkConstraintData& self = get_data(*this);
+
+		if (self.has_distance)
+			return self.distance;
+
+		if (self.is_valid() && self.world)
+			return to_coord(b2DistanceJoint_GetLength(self.b2joint), self.ppm());
+
+		return 0;
+	}
+
+	bool
+	LinkConstraint::has_distance () const
+	{
+		return get_data(*this).has_distance;
+	}
+
+	coord
+	LinkConstraint::current_distance () const
+	{
+		const LinkConstraintData& self = get_data(*this);
+
+		if (!self.is_valid() || !self.world) return 0;
+
+		return to_coord(b2DistanceJoint_GetCurrentLength(self.b2joint), self.ppm());
+	}
+
+	static void
+	update_range (LinkConstraint* c, bool has_range, coord min, coord max)
+	{
+		if (min > max || min < 0)
+			argument_error(__FILE__, __LINE__);
+
+		LinkConstraintData& self = get_data(*c);
+
+		self.has_range = has_range;
+		self.range_min = min;
+		self.range_max = max;
+		self.update_params();
+	}
+
+	void
+	LinkConstraint::set_range (coord min, coord max)
+	{
+		update_range(this, true, min, max);
+	}
+
+	void
+	LinkConstraint::clear_range ()
+	{
+		update_range(this, false, 0, 0);
+	}
+
+	coord
+	LinkConstraint::range_min () const
+	{
+		return get_data(*this).range_min;
+	}
+
+	coord
+	LinkConstraint::range_max () const
+	{
+		return get_data(*this).range_max;
+	}
+
+	bool
+	LinkConstraint::has_range () const
+	{
+		return get_data(*this).has_range;
+	}
+
+	static void
+	update_motor (LinkConstraint* c, bool has_motor, coord speed)
+	{
+		LinkConstraintData& self = get_data(*c);
+
+		self.has_motor   = has_motor;
+		self.motor_speed = speed;
+		self.update_params();
+	}
+
+	void
+	LinkConstraint::set_motor (coord pixel_per_second)
+	{
+		update_motor(this, true, pixel_per_second);
+	}
+
+	void
+	LinkConstraint::clear_motor ()
+	{
+		update_motor(this, false, 0);
+	}
+
+	coord
+	LinkConstraint::motor () const
+	{
+		return get_data(*this).motor_speed;
+	}
+
+	bool
+	LinkConstraint::has_motor () const
+	{
+		return get_data(*this).has_motor;
+	}
+
+
+	struct RailConstraintData : public Constraint::Data
+	{
+
+		Point axis        = Point(0, 1);
+
+		bool  rotate      = false;
+
+		bool  has_range   = false;
+
+		coord range_min   = 0;
+
+		coord range_max   = 0;
+
+		bool  has_motor   = false;
+
+		float motor_speed = 0;// px/sec (rail) or degree/sec (rotate: true)
+
+		b2JointId create_joint (
+			b2WorldId world, b2BodyId body0, b2BodyId body1, float ppm) override
+		{
+			resolve_anchors(body0, body1, ppm);
+
+			// the declaring side goes to bodyB because the mouse joint
+			// assumes bodyA is static
+			if (rotate)
+			{
+				b2WheelJointDef def  = b2DefaultWheelJointDef();
+				def.bodyIdA          = body1;
+				def.bodyIdB          = body0;
+				def.localAnchorA     = anchor1;
+				def.localAnchorB     = anchor0;
+				def.localAxisA       = b2axis();
+				def.enableSpring     = spring > 0;
+				def.hertz            = spring;
+				def.dampingRatio     = damping;
+				def.enableLimit      = has_range;
+				def.lowerTranslation = to_b2coord(range_min, ppm);
+				def.upperTranslation = to_b2coord(range_max, ppm);
+				def.enableMotor      = has_motor;
+				def.motorSpeed       = motor_b2speed(ppm);
+				def.maxMotorTorque   = default_max_force(body0);
+				def.collideConnected = collide;
+				return b2CreateWheelJoint(world, &def);
+			}
+			else
+			{
+				b2PrismaticJointDef def = b2DefaultPrismaticJointDef();
+				def.bodyIdA             = body1;
+				def.bodyIdB             = body0;
+				def.localAnchorA        = anchor1;
+				def.localAnchorB        = anchor0;
+				def.localAxisA          = b2axis();
+				def.referenceAngle      = ref_angle;
+				def.enableSpring        = spring > 0;
+				def.hertz               = spring;
+				def.dampingRatio        = damping;
+				def.enableLimit         = has_range;
+				def.lowerTranslation    = to_b2coord(range_min, ppm);
+				def.upperTranslation    = to_b2coord(range_max, ppm);
+				def.enableMotor         = has_motor;
+				def.motorSpeed          = motor_b2speed(ppm);
+				def.maxMotorForce       = default_max_force(body0);
+				def.collideConnected    = collide;
+				return b2CreatePrismaticJoint(world, &def);
+			}
+		}
+
+		void apply_params (float ppm) override
+		{
+			b2Joint_SetLocalAxisA(b2joint, b2axis());
+
+			if (b2Joint_GetType(b2joint) == b2_wheelJoint)
+			{
+				b2WheelJoint_EnableSpring(         b2joint, spring > 0);
+				b2WheelJoint_SetSpringHertz(       b2joint, spring);
+				b2WheelJoint_SetSpringDampingRatio(b2joint, damping);
+				b2WheelJoint_EnableLimit(          b2joint, has_range);
+				if (has_range)
+				{
+					float min = to_b2coord(range_min, ppm), max = to_b2coord(range_max, ppm);
+					b2WheelJoint_SetLimits(          b2joint, min, max);
+				}
+				b2WheelJoint_EnableMotor(          b2joint, has_motor);
+				b2WheelJoint_SetMotorSpeed(        b2joint, motor_b2speed(ppm));
+			}
+			else
+			{
+				b2PrismaticJoint_EnableSpring(         b2joint, spring > 0);
+				b2PrismaticJoint_SetSpringHertz(       b2joint, spring);
+				b2PrismaticJoint_SetSpringDampingRatio(b2joint, damping);
+				b2PrismaticJoint_EnableLimit(          b2joint, has_range);
+				if (has_range)
+				{
+					float min = to_b2coord(range_min, ppm), max = to_b2coord(range_max, ppm);
+					b2PrismaticJoint_SetLimits(          b2joint, min, max);
+				}
+				b2PrismaticJoint_EnableMotor(          b2joint, has_motor);
+				b2PrismaticJoint_SetMotorSpeed(        b2joint, motor_b2speed(ppm));
+			}
+		}
+
+		b2Vec2 b2axis () const
+		{
+			return b2Normalize(b2Vec2(axis.x, axis.y));
+		}
+
+		float motor_b2speed (float ppm) const
+		{
+			return rotate
+				?	Xot::deg2rad(motor_speed)
+				:	to_b2coord(motor_speed, ppm);
+		}
+
+	};// RailConstraintData
+
+
+	static RailConstraintData&
+	get_data (RailConstraint& constraint)
+	{
+		return (RailConstraintData&) *constraint.self;
+	}
+
+	static const RailConstraintData&
+	get_data (const RailConstraint& constraint)
+	{
+		return get_data(const_cast<RailConstraint&>(constraint));
+	}
+
+
+	RailConstraint::RailConstraint ()
+	:	Super(new RailConstraintData)
+	{
+	}
+
+	RailConstraint::~RailConstraint ()
+	{
+	}
+
+	void
+	RailConstraint::set_axis (coord x, coord y)
+	{
+		set_axis(Point(x, y));
+	}
+
+	void
+	RailConstraint::set_axis (const Point& direction)
+	{
+		if (direction.x == 0 && direction.y == 0)
+			argument_error(__FILE__, __LINE__);
+
+		RailConstraintData& self = get_data(*this);
+
+		self.axis = direction;
+		self.update_params();
+	}
+
+	const Point&
+	RailConstraint::axis () const
+	{
+		return get_data(*this).axis;
+	}
+
+	void
+	RailConstraint::set_rotate (bool state)
+	{
+		RailConstraintData& self = get_data(*this);
+
+		if (state == self.rotate) return;
+
+		self.rotate = state;
+		if (self.is_valid()) reactivate_constraint(this);
+	}
+
+	bool
+	RailConstraint::can_rotate () const
+	{
+		return get_data(*this).rotate;
+	}
+
+	static void
+	update_range (RailConstraint* c, bool has_range, float min, float max)
+	{
+		if (min > max)
+			argument_error(__FILE__, __LINE__);
+
+		RailConstraintData& self = get_data(*c);
+
+		self.has_range = has_range;
+		self.range_min = min;
+		self.range_max = max;
+		self.update_params();
+	}
+
+	void
+	RailConstraint::set_range (coord min, coord max)
+	{
+		update_range(this, true, min, max);
+	}
+
+	void
+	RailConstraint::clear_range ()
+	{
+		update_range(this, false, 0, 0);
+	}
+
+	coord
+	RailConstraint::range_min () const
+	{
+		return get_data(*this).range_min;
+	}
+
+	coord
+	RailConstraint::range_max () const
+	{
+		return get_data(*this).range_max;
+	}
+
+	bool
+	RailConstraint::has_range () const
+	{
+		return get_data(*this).has_range;
+	}
+
+	static void
+	update_motor (RailConstraint* c, bool has_motor, float speed)
+	{
+		RailConstraintData& self = get_data(*c);
+
+		self.has_motor   = has_motor;
+		self.motor_speed = speed;
+		self.update_params();
+	}
+
+	void
+	RailConstraint::set_motor (float speed)
+	{
+		update_motor(this, true, speed);
+	}
+
+	void
+	RailConstraint::clear_motor ()
+	{
+		update_motor(this, false, 0);
+	}
+
+	float
+	RailConstraint::motor () const
+	{
+		return get_data(*this).motor_speed;
+	}
+
+	bool
+	RailConstraint::has_motor () const
+	{
+		return get_data(*this).has_motor;
+	}
+
+
+	struct ChaseConstraintData : public Constraint::Data
+	{
+
+		Pin target;
+
+		bool has_force = false;
+
+		float force    = 0;
+
+		ChaseConstraintData ()
+		{
+			spring = DEFAULT_CHASE_SPRING;
+		}
+
+		b2JointId create_joint (
+			b2WorldId world, b2BodyId body0, b2BodyId body1, float ppm) override
+		{
+			Point pos0 = pins[0].position() ? *pins[0].position() : view_center(pins[0].view());
+
+			// the declaring side goes to bodyB because the mouse joint
+			// assumes bodyA is static
+			b2MouseJointDef def  = b2DefaultMouseJointDef();
+			def.bodyIdA          = body1;
+			def.bodyIdB          = body0;
+			def.target           = b2Body_GetWorldPoint(body0, to_b2vec2(pos0, ppm));
+			def.hertz            = spring;
+			def.dampingRatio     = damping;
+			def.maxForce         = has_force ? force : default_max_force(body0);
+			def.collideConnected = collide;
+
+			b2JointId id = b2CreateMouseJoint(world, &def);
+			if (b2Joint_IsValid(id))
+			{
+				b2Vec2 target_pos;
+				if (get_target_pos(&target_pos, ppm))
+					b2MouseJoint_SetTarget(id, target_pos);
+			}
+			return id;
+		}
+
+		void apply_params (float ppm) override
+		{
+			b2MouseJoint_SetSpringHertz(       b2joint, spring);
+			b2MouseJoint_SetSpringDampingRatio(b2joint, damping);
+			if (has_force)
+				b2MouseJoint_SetMaxForce(        b2joint, force);
+
+			b2Vec2 target_pos;
+			if (get_target_pos(&target_pos, ppm))
+				b2MouseJoint_SetTarget(          b2joint, target_pos);
+		}
+
+		void on_world_update (float ppm) override
+		{
+			if (!is_valid() || !target.view())
+				return;
+
+			b2Vec2 pos;
+			if (get_target_pos(&pos, ppm))
+			{
+				b2MouseJoint_SetTarget(b2joint, pos);
+				b2Joint_WakeBodies(b2joint);
+			}
+		}
+
+		bool get_target_pos (b2Vec2* pos, float ppm)
+		{
+			assert(pos);
+
+			View* view = target.view();
+			if (view)
+			{
+				Body* body = View_get_body(view, false);
+				if (!body || Body_is_temporary(*body))
+					return false;
+
+				Point p = target.position() ? *target.position() : view_center(view);
+				*pos    = b2Body_GetWorldPoint(Body_get_id(body), to_b2vec2(p, ppm));
+				return true;
+			}
+
+			if (target.position())
+			{
+				*pos = to_b2vec2(*target.position(), ppm);
+				return true;
+			}
+
+			return false;
+		}
+
+	};// ChaseConstraintData
+
+
+	static ChaseConstraintData&
+	get_data (ChaseConstraint& constraint)
+	{
+		return (ChaseConstraintData&) *constraint.self;
+	}
+
+	static const ChaseConstraintData&
+	get_data (const ChaseConstraint& constraint)
+	{
+		return get_data(const_cast<ChaseConstraint&>(constraint));
+	}
+
+
+	ChaseConstraint::ChaseConstraint ()
+	:	Super(new ChaseConstraintData)
+	{
+	}
+
+	ChaseConstraint::~ChaseConstraint ()
+	{
+	}
+
+	void
+	ChaseConstraint::set_target (const Pin& target)
+	{
+		ChaseConstraintData& self = get_data(*this);
+
+		if (target.view() && target.view() == self.pins[0].view())
+			argument_error(__FILE__, __LINE__, "can not chase itself");
+
+		self.target = target;
+		self.update_params();
+	}
+
+	const Pin&
+	ChaseConstraint::target () const
+	{
+		return get_data(*this).target;
+	}
+
+	void
+	ChaseConstraint::set_force (float max_force)
+	{
+		if (max_force < 0)
+			argument_error(__FILE__, __LINE__);
+
+		ChaseConstraintData& self = get_data(*this);
+
+		self.has_force = true;
+		self.force     = max_force;
+		self.update_params();
+	}
+
+	void
+	ChaseConstraint::clear_force ()
+	{
+		ChaseConstraintData& self = get_data(*this);
+
+		self.has_force = false;
+		self.force     = 0;
+
+		if (self.is_valid() && self.world)
+		{
+			View* view = self.pins[0].view();
+			Body* body = view ? View_get_body(view, false) : NULL;
+			if (body)
+				b2MouseJoint_SetMaxForce(self.b2joint, default_max_force(Body_get_id(body)));
+		}
+	}
+
+	float
+	ChaseConstraint::force () const
+	{
+		const ChaseConstraintData& self = get_data(*this);
+
+		if (self.has_force)
+			return self.force;
+
+		if (self.is_valid())
+			return b2MouseJoint_GetMaxForce(self.b2joint);
+
+		return 0;
+	}
+
+	bool
+	ChaseConstraint::has_force () const
+	{
+		return get_data(*this).has_force;
+	}
+
+
+}// Reflex

--- a/reflex/src/constraint.cpp
+++ b/reflex/src/constraint.cpp
@@ -5,6 +5,7 @@
 #include "reflex/pin.h"
 #include "reflex/exception.h"
 #include "view.h"
+#include "selector.h"
 #include "body.h"
 #include "world.h"
 
@@ -68,6 +69,8 @@ namespace Reflex
 		b2Vec2 anchor1     = {0, 0};
 
 		float ref_angle    = 0;
+
+		SelectorPtr pselector;
 
 		virtual ~Data ()
 		{
@@ -448,6 +451,12 @@ namespace Reflex
 	Constraint::operator ! () const
 	{
 		return !operator bool();
+	}
+
+	SelectorPtr*
+	Constraint::get_selector_ptr ()
+	{
+		return &self->pselector;
 	}
 
 

--- a/reflex/src/constraint.h
+++ b/reflex/src/constraint.h
@@ -1,0 +1,42 @@
+// -*- c++ -*-
+#pragma once
+#ifndef __REFLEX_SRC_CONSTRAINT_H__
+#define __REFLEX_SRC_CONSTRAINT_H__
+
+
+#include <box2d/id.h>
+#include "reflex/constraint.h"
+
+
+namespace Reflex
+{
+
+
+	class View;
+	class World;
+
+
+	b2JointId Constraint_get_id (const Constraint* constraint);
+
+	void Constraint_set_pins (
+		Constraint* constraint,
+		View* view0, const Point* position0,
+		View* view1, const Point* position1);
+
+	bool Constraint_activate   (Constraint* constraint);
+
+	void Constraint_deactivate (Constraint* constraint);
+
+	void Constraint_sever (Constraint* constraint);
+
+	void Constraint_on_world_destroyed (Constraint* constraint);
+
+	void Constraint_on_world_update    (Constraint* constraint);
+
+	bool Constraint_has_world_mismatch (const Constraint* constraint);
+
+
+}// Reflex
+
+
+#endif//EOH

--- a/reflex/src/pin.cpp
+++ b/reflex/src/pin.cpp
@@ -1,0 +1,134 @@
+#include "reflex/pin.h"
+
+
+#include "reflex/exception.h"
+#include "view.h"
+#include "constraint.h"
+
+
+namespace Reflex
+{
+
+
+	struct Pin::Data
+	{
+
+		Xot::WeakRef<View> view;
+
+		std::unique_ptr<Point> pposition;
+
+	};// Pin::Data
+
+
+	template <typename T>
+	static T*
+	setup_constraint (
+		T* constraint,
+		View* view0, const Point* position0,
+		View* view1, const Point* position1)
+	{
+		if (!view0)
+			invalid_state_error(__FILE__, __LINE__, "the pin has no view");
+
+		Constraint_set_pins(constraint, view0, position0, view1, position1);
+		View_add_constraint(view0, constraint);
+		return constraint;
+	}
+
+
+	Pin::Pin ()
+	{
+	}
+
+	Pin::Pin (coord x, coord y)
+	:	Pin(NULL, Point(x, y))
+	{
+	}
+
+	Pin::Pin (const Point& position)
+	:	Pin(NULL, position)
+	{
+	}
+
+	Pin::Pin (View* view)
+	{
+		self->view = view;
+	}
+
+	Pin::Pin (View* view, coord x, coord y)
+	:	Pin(view, Point(x, y))
+	{
+	}
+
+	Pin::Pin (View* view, const Point& position)
+	{
+		self->view = view;
+		self->pposition.reset(new Point(position));
+	}
+
+	SnapConstraint*
+	Pin::snap (Pin target)
+	{
+		return setup_constraint(
+			new SnapConstraint(),
+			view(), position(), target.view(), target.position());
+	}
+
+	LinkConstraint*
+	Pin::link (Pin target)
+	{
+		return setup_constraint(
+			new LinkConstraint(),
+			view(), position(), target.view(), target.position());
+	}
+
+	RailConstraint*
+	Pin::rail (Pin target)
+	{
+		return setup_constraint(
+			new RailConstraint(),
+			view(), position(), target.view(), target.position());
+	}
+
+	ChaseConstraint*
+	Pin::chase (Pin target)
+	{
+		ChaseConstraint* chase = setup_constraint(
+			new ChaseConstraint(),
+			view(), position(), NULL, NULL);
+		chase->set_target(target);
+		return chase;
+	}
+
+	View*
+	Pin::view ()
+	{
+		return self->view.get();
+	}
+
+	const View*
+	Pin::view () const
+	{
+		return const_cast<Pin*>(this)->view();
+	}
+
+	const Point*
+	Pin::position () const
+	{
+		return self->pposition ? self->pposition.get() : NULL;
+	}
+
+	Pin::operator bool () const
+	{
+		return true;
+	}
+
+	bool
+	Pin::operator ! () const
+	{
+		return !operator bool();
+	}
+
+
+}// Reflex
+

--- a/reflex/src/pin.cpp
+++ b/reflex/src/pin.cpp
@@ -70,7 +70,7 @@ namespace Reflex
 	Pin::snap (Pin target)
 	{
 		return setup_constraint(
-			new SnapConstraint(),
+			Xot::Ref<SnapConstraint>(new SnapConstraint()).get(),
 			view(), position(), target.view(), target.position());
 	}
 
@@ -78,7 +78,7 @@ namespace Reflex
 	Pin::link (Pin target)
 	{
 		return setup_constraint(
-			new LinkConstraint(),
+			Xot::Ref<LinkConstraint>(new LinkConstraint()).get(),
 			view(), position(), target.view(), target.position());
 	}
 
@@ -86,15 +86,18 @@ namespace Reflex
 	Pin::rail (Pin target)
 	{
 		return setup_constraint(
-			new RailConstraint(),
+			Xot::Ref<RailConstraint>(new RailConstraint()).get(),
 			view(), position(), target.view(), target.position());
 	}
 
 	ChaseConstraint*
 	Pin::chase (Pin target)
 	{
+		if (target.view() && target.view() == view())
+			argument_error(__FILE__, __LINE__, "can not chase itself");
+
 		ChaseConstraint* chase = setup_constraint(
-			new ChaseConstraint(),
+			Xot::Ref<ChaseConstraint>(new ChaseConstraint()).get(),
 			view(), position(), NULL, NULL);
 		chase->set_target(target);
 		return chase;

--- a/reflex/src/view.cpp
+++ b/reflex/src/view.cpp
@@ -2260,6 +2260,22 @@ namespace Reflex
 		self->sever_constraints();
 	}
 
+	View::ConstraintList
+	View::find_constraints (const Selector& selector) const
+	{
+		ConstraintList result;
+		ConstraintList* pconstraints = self->pconstraints.get();
+		if (pconstraints)
+		{
+			for (auto& constraint : *pconstraints)
+			{
+				if (constraint->selector().contains(selector))
+					result.push_back(constraint);
+			}
+		}
+		return result;
+	}
+
 	static View::ConstraintList empty_constraints;
 
 	View::constraint_iterator

--- a/reflex/src/view.cpp
+++ b/reflex/src/view.cpp
@@ -20,6 +20,7 @@
 #include "world.h"
 #include "body.h"
 #include "fixture.h"
+#include "constraint.h"
 
 
 namespace Reflex
@@ -84,35 +85,37 @@ namespace Reflex
 		uint flags         =
 			FLAG_CLIP | FLAG_RESIZE_TO_FIT | REDRAW | UPDATE_LAYOUT | UPDATE_STYLE;
 
-		std::unique_ptr<Point>       ppivot;
+		std::unique_ptr<Point>          ppivot;
 
-		std::unique_ptr<Point>       pscroll;
+		std::unique_ptr<Point>          pscroll;
 
-		SelectorPtr                  pselector;
+		SelectorPtr                     pselector;
 
-		std::unique_ptr<SelectorSet> pselectors_for_update;
+		std::unique_ptr<SelectorSet>    pselectors_for_update;
 
-		std::unique_ptr<Image>       pcache_image;
+		std::unique_ptr<Image>          pcache_image;
 
-		std::unique_ptr<Timers>      ptimers;
+		std::unique_ptr<Timers>         ptimers;
 
-		std::unique_ptr<Style>       pstyle;
+		std::unique_ptr<Style>          pstyle;
 
-		std::unique_ptr<StyleList>   pstyles;
+		std::unique_ptr<StyleList>      pstyles;
 
-		Shape::Ref                   pshape;
+		Shape::Ref                      pshape;
 
-		std::unique_ptr<ShapeList>   pshapes;
+		std::unique_ptr<ShapeList>      pshapes;
 
-		Filter::Ref                  pfilter;
+		Filter::Ref                     pfilter;
 
-		std::unique_ptr<Body>        pbody;
+		std::unique_ptr<Body>           pbody;
 
-		std::unique_ptr<World>       pchild_world;
+		std::unique_ptr<ConstraintList> pconstraints;
 
-		std::unique_ptr<ChildList>   pchildren;
+		std::unique_ptr<World>          pchild_world;
 
-		std::unique_ptr<ChildList>   pchildren_sorted;
+		std::unique_ptr<ChildList>      pchildren;
+
+		std::unique_ptr<ChildList>      pchildren_sorted;
 
 		Point& pivot ()
 		{
@@ -176,6 +179,24 @@ namespace Reflex
 			return *pshapes;
 		}
 
+		ConstraintList& constraints ()
+		{
+			if (!pconstraints) pconstraints.reset(new ConstraintList);
+			return *pconstraints;
+		}
+
+		void sever_constraints ()
+		{
+			if (!pconstraints) return;
+
+			ConstraintList list;
+			list.swap(*pconstraints);
+			for (auto& constraint : list)
+				Constraint_sever(constraint.get());
+
+			pconstraints.reset();
+		}
+
 		template <typename FUN>
 		void each_shape (FUN fun)
 		{
@@ -201,6 +222,17 @@ namespace Reflex
 			{
 				Shape_update(shape, force);
 			});
+		}
+
+		void update_constraints ()
+		{
+			if (!pconstraints) return;
+
+			for (auto& constraint : *pconstraints)
+			{
+				Constraint_deactivate(constraint.get());
+				Constraint_activate(constraint.get());
+			}
 		}
 
 		void resize_shapes (FrameEvent* e)
@@ -287,6 +319,7 @@ namespace Reflex
 			}
 
 			update_shapes(true);
+			update_constraints();
 		}
 
 		World* parent_world (bool create = true)
@@ -830,6 +863,57 @@ namespace Reflex
 		if (!view) return NULL;
 
 		return create ? &view->self->body() : view->self->pbody.get();
+	}
+
+	const Body*
+	View_get_body (const View* view)
+	{
+		return View_get_body(const_cast<View*>(view), false);
+	}
+
+	void
+	View_add_constraint (View* view, Constraint* constraint)
+	{
+		if (!view || !constraint)
+			argument_error(__FILE__, __LINE__);
+
+		if (constraint->is_removed())
+			invalid_state_error(__FILE__, __LINE__, "constraint is already removed");
+
+		if (constraint->view(0) != view)
+			argument_error(__FILE__, __LINE__, "the constraint does not belong to this view");
+
+		auto& list = view->self->constraints();
+		if (std::find(list.begin(), list.end(), constraint) != list.end())
+			invalid_state_error(__FILE__, __LINE__, "the constraint is already added");
+
+		// the mismatch is not detectable before activation because
+		// activating is what creates the missing bodies
+		if (
+			!Constraint_activate(constraint) &&
+			Constraint_has_world_mismatch(constraint))
+		{
+			physics_error(__FILE__, __LINE__, "the views belong to different worlds");
+		}
+
+		list.push_back(constraint);
+		View* view1 = constraint->view(1);
+		if (view1) view1->self->constraints().push_back(constraint);
+	}
+
+	void
+	View_remove_constraint (View* view, Constraint* constraint)
+	{
+		if (!view || !constraint)
+			argument_error(__FILE__, __LINE__);
+
+		auto* list = view->self->pconstraints.get();
+		if (!list) return;
+
+		auto it = std::find(list->begin(), list->end(), constraint);
+		if (it != list->end()) list->erase(it);
+
+		if (list->empty()) view->self->pconstraints.reset();
 	}
 
 	bool
@@ -1586,6 +1670,8 @@ namespace Reflex
 
 	View::~View ()
 	{
+		self->sever_constraints();
+
 		clear_children();// to delete child shapes before world.
 	}
 
@@ -2166,6 +2252,42 @@ namespace Reflex
 	{
 		if (!self->pshapes) return empty_shapes.end();
 		return self->pshapes->end();
+	}
+
+	void
+	View::clear_constraints ()
+	{
+		self->sever_constraints();
+	}
+
+	static View::ConstraintList empty_constraints;
+
+	View::constraint_iterator
+	View::constraint_begin ()
+	{
+		if (!self->pconstraints) return empty_constraints.begin();
+		return self->pconstraints->begin();
+	}
+
+	View::const_constraint_iterator
+	View::constraint_begin () const
+	{
+		if (!self->pconstraints) return empty_constraints.begin();
+		return self->pconstraints->begin();
+	}
+
+	View::constraint_iterator
+	View::constraint_end ()
+	{
+		if (!self->pconstraints) return empty_constraints.end();
+		return self->pconstraints->end();
+	}
+
+	View::const_constraint_iterator
+	View::constraint_end () const
+	{
+		if (!self->pconstraints) return empty_constraints.end();
+		return self->pconstraints->end();
 	}
 
 	void

--- a/reflex/src/view.h
+++ b/reflex/src/view.h
@@ -15,6 +15,7 @@ namespace Reflex
 
 
 	class Body;
+	class Constraint;
 
 
 	void View_set_window (View* view, Window* window);
@@ -23,7 +24,13 @@ namespace Reflex
 
 	const Style& View_get_style (const View* view);
 
-	Body* View_get_body (View* view, bool create = true);
+	      Body* View_get_body (      View* view, bool create = true);
+
+	const Body* View_get_body (const View* view);
+
+	void View_add_constraint    (View* view, Constraint* constraint);
+
+	void View_remove_constraint (View* view, Constraint* constraint);
 
 	bool View_is_active (const View& view);
 

--- a/reflex/src/world.cpp
+++ b/reflex/src/world.cpp
@@ -2,6 +2,7 @@
 
 
 #include <assert.h>
+#include <algorithm>
 #include <memory>
 #include <vector>
 #include <map>
@@ -9,8 +10,9 @@
 #include <box2d/box2d.h>
 #include "reflex/event.h"
 #include "reflex/exception.h"
-#include "shape.h"
 #include "view.h"
+#include "shape.h"
+#include "constraint.h"
 #include "body.h"
 #include "fixture.h"
 
@@ -274,11 +276,23 @@ namespace Reflex
 
 		bool stepping     = false;
 
-		std::unique_ptr<DebugDraw> debug_draw;
-
 		// tracked to deliver contact-end events for shapes that Box2D has already
 		// forgotten on destruction
 		ShapePairMap touching_pairs;
+
+		std::vector<Xot::WeakRef<Constraint>> constraints;
+
+		// fixture-less static body for constraints that anchor to the world
+		// (e.g. chasing a target point) without affecting any collision
+		std::unique_ptr<Body>      pground;
+
+		std::unique_ptr<DebugDraw> pdebug_draw;
+
+		Body* ground (World* world)
+		{
+			if (!pground) pground.reset(new Body(world));
+			return pground.get();
+		}
 
 		void begin_contact (b2ShapeId b2shape1, b2ShapeId b2shape2, bool is_sensor_event)
 		{
@@ -338,6 +352,25 @@ namespace Reflex
 			}
 		}
 
+		void update_constraints ()
+		{
+			for (auto& constraint : constraints)
+			{
+				if (constraint)
+					Constraint_on_world_update(constraint);
+			}
+		}
+
+		void clear_constraints ()
+		{
+			for (auto& constraint : constraints)
+			{
+				if (constraint)
+					Constraint_on_world_destroyed(constraint);
+			}
+			constraints.clear();
+		}
+
 	};// World::Data
 
 
@@ -361,6 +394,8 @@ namespace Reflex
 	World::~World ()
 	{
 		self->touching_pairs.clear();
+		self->clear_constraints();
+		self->pground.reset();
 
 		b2DestroyWorld(self->b2world);
 		self->b2world = b2_nullWorldId;
@@ -377,6 +412,8 @@ namespace Reflex
 
 		for (int i = 0; i < count; ++i)
 		{
+			self->update_constraints();
+
 			self->stepping = true;
 			b2World_Step(self->b2world, dt, 4);
 			self->stepping = false;
@@ -426,15 +463,15 @@ namespace Reflex
 		if (state == debug()) return;
 
 		if (state)
-			self->debug_draw.reset(new DebugDraw(self->ppm));
+			self->pdebug_draw.reset(new DebugDraw(self->ppm));
 		else
-			self->debug_draw.reset();
+			self->pdebug_draw.reset();
 	}
 
 	bool
 	World::debug () const
 	{
-		return !!self->debug_draw;
+		return !!self->pdebug_draw;
 	}
 
 	void
@@ -446,11 +483,11 @@ namespace Reflex
 	void
 	World::on_draw (Painter* painter)
 	{
-		if (!self->debug_draw) return;
+		if (!self->pdebug_draw) return;
 
-		self->debug_draw->begin(painter);
-		b2World_Draw(self->b2world, self->debug_draw->b2ptr());
-		self->debug_draw->end();
+		self->pdebug_draw->begin(painter);
+		b2World_Draw(self->b2world, self->pdebug_draw->b2ptr());
+		self->pdebug_draw->end();
 	}
 
 
@@ -460,10 +497,24 @@ namespace Reflex
 		return world ? world->self->b2world : b2_nullWorldId;
 	}
 
-	bool
-	World_is_stepping (const World* world)
+	void
+	World_add_constraint (World* world, Constraint* constraint)
 	{
-		return world ? world->self->stepping : false;
+		if (!world || !constraint)
+			argument_error(__FILE__, __LINE__);
+
+		world->self->constraints.emplace_back(constraint);
+	}
+
+	void
+	World_remove_constraint (World* world, Constraint* constraint)
+	{
+		if (!world || !constraint)
+			argument_error(__FILE__, __LINE__);
+
+		std::erase_if(
+			world->self->constraints,
+			[=](auto& c) {return !c || c == constraint;});
 	}
 
 	void
@@ -488,6 +539,18 @@ namespace Reflex
 
 		for (auto& pair : ended)
 			call_contact_events(pair.first, pair.second, ContactEvent::END);
+	}
+
+	bool
+	World_is_stepping (const World* world)
+	{
+		return world ? world->self->stepping : false;
+	}
+
+	const Body*
+	World_get_ground (World* world)
+	{
+		return world ? world->self->ground(world) : NULL;
 	}
 
 	World*

--- a/reflex/src/world.h
+++ b/reflex/src/world.h
@@ -19,6 +19,7 @@ namespace Reflex
 
 	class View;
 	class Body;
+	class Constraint;
 
 
 	class World : public Xot::NonCopyable
@@ -104,9 +105,15 @@ namespace Reflex
 
 	b2WorldId World_get_id (const World* world);
 
-	bool World_is_stepping (const World* world);
+	void World_add_constraint    (World* world, Constraint* constraint);
+
+	void World_remove_constraint (World* world, Constraint* constraint);
 
 	void World_end_contacts_for (World* world, b2ShapeId b2shape);
+
+	bool World_is_stepping (const World* world);
+
+	const Body* World_get_ground (World* world);
 
 	World* World_get_temporary ();
 

--- a/reflex/test/helper.rb
+++ b/reflex/test/helper.rb
@@ -8,3 +8,10 @@ require 'reflex'
 require 'test/unit'
 
 include Xot::Test
+
+
+def assert_equal_point(expected, actual, delta = 0.01, *args)
+  assert_in_delta expected.x, actual.x, delta, *args
+  assert_in_delta expected.y, actual.y, delta, *args
+  assert_in_delta expected.z, actual.z, delta, *args
+end

--- a/reflex/test/test_chase_constraint.rb
+++ b/reflex/test/test_chase_constraint.rb
@@ -1,0 +1,124 @@
+require_relative 'helper'
+
+
+class TestChaseConstraint < Test::Unit::TestCase
+
+  def window()
+    Reflex::Window.new
+  end
+
+  def view(x = 0, y = 0, w = 50, h = 50, **options, &block)
+    Reflex::View.new(
+      frame: [x, y, w, h],
+      shape: Reflex::RectShape.new(density: 1),
+      **options, &block)
+  end
+
+  def point(...)
+    Reflex::Point.new(...)
+  end
+
+  def setup_views(win = window)
+    v1 = view 100, 100, dynamic: true
+    v2 = view 200, 100, static:  true
+    win&.add v1
+    win&.add v2
+    [v1, v2, win, win&.root]
+  end
+
+  def test_initial_state()
+    v1, v2, = setup_views
+
+    assert_equal v1,     v1.chase(v2)              .pins[0].view
+    assert_nil           v1.chase(v2)              .pins[1].view
+    assert_equal v2,     v1.chase(v2)              .target.view
+    assert_nil           v1.chase(v2)              .force
+    assert_equal 1,      v1.chase(v2, force: 1)    .force
+    assert_equal 5,      v1.chase(v2)              .spring
+    assert_equal 2,      v1.chase(v2, spring: 2)   .spring
+    assert_in_delta 0.7, v1.chase(v2)              .damping
+    assert_in_delta 0.1, v1.chase(v2, damping: 0.1).damping
+    assert_false         v1.chase(v2)              .collide?
+    assert_true          v1.chase(v2)              .active?
+    assert_false         v1.chase(v2)              .removed?
+  end
+
+  def test_chase_view()
+    v1, v2, _, root = setup_views
+
+    c = v1.chase v2
+    assert_equal v2, c.target.view
+
+    root.update_world
+    assert_operator v1.linear_velocity.x, :>, 0
+  end
+
+  def test_chase_world_point()
+    v1, _, _, root = setup_views
+
+    c = v1.chase            [300, 300]
+    assert_nil                          c.target.view
+    assert_equal_point point(300, 300), c.target.pos
+
+    root.update_world
+    assert_operator v1.linear_velocity.x, :>, 0
+    assert_operator v1.linear_velocity.y, :>, 0
+  end
+
+  def test_grabbing_corner_creates_torque()
+    v1, _, _, root = setup_views
+
+    c = v1.pin(0, 0).chase [300, 100], spring: 8
+    assert_equal_point point(0, 0), c.pins[0].pos
+
+    3.times {root.update_world}
+    assert_operator v1.angular_velocity.abs, :>, 1
+  end
+
+  def test_chase_to_itself_error()
+    v1, v2, = setup_views
+
+    assert_raise(ArgumentError) {v1.chase v1}
+    assert_raise(ArgumentError) {v1.chase(v2).target = v1}
+  end
+
+  def test_target()
+    v1, v2, = setup_views
+
+    c = v1.chase [300, 300]
+    assert_nil                          c.target.view
+    assert_equal_point point(300, 300), c.target.pos
+
+    c.target =   v2
+    assert_equal v2,                    c.target.view
+    assert_nil                          c.target.pos
+
+    c.target = v2.pin(0, 0)
+    assert_equal v2,                    c.target.view
+    assert_equal_point point(0, 0),     c.target.pos
+
+    c.target = [v2, 5, 5]
+    assert_equal v2,                    c.target.view
+    assert_equal_point point(5, 5),     c.target.pos
+
+    c.target = nil
+    assert_nil                          c.target.view
+    assert_nil                          c.target.pos
+  end
+
+  def test_force()
+    v1, = setup_views
+
+    c = v1.chase [300, 100], force: 500
+    assert_equal 500, c.force
+
+    c.force = nil
+    assert_nil        c.force
+
+    c.force = 100
+    assert_equal 100, c.force
+
+    assert_raise(ArgumentError) {c.force = -1}
+  end
+
+end# TestChaseConstraint

--- a/reflex/test/test_constraint.rb
+++ b/reflex/test/test_constraint.rb
@@ -155,8 +155,13 @@ class TestConstraint < Test::Unit::TestCase
   end
 
   def test_constrain_to_itself_error()
-    v, = setup_views
-    assert_raise(ArgumentError) {v.snap v}
+    setup_views.tap do |v,|
+      assert_raise(ArgumentError) {v.snap  v}
+    end
+    setup_views.tap do |v,|
+      assert_raise(ArgumentError) {v.chase v}
+      assert_equal [], v.constraints.to_a # rejected self-constraint leaves no orphan
+    end
   end
 
   def test_world_mismatch_error()

--- a/reflex/test/test_constraint.rb
+++ b/reflex/test/test_constraint.rb
@@ -1,0 +1,152 @@
+require_relative 'helper'
+
+
+class TestConstraint < Test::Unit::TestCase
+
+  def window()
+    Reflex::Window.new
+  end
+
+  def view(x = 0, y = 0, w = 50, h = 50, **options, &block)
+    Reflex::View.new(
+      frame: [x, y, w, h],
+      shape: Reflex::RectShape.new(density: 1),
+      **options, &block)
+  end
+
+  def point(...)
+    Reflex::Point.new(...)
+  end
+
+  def setup_views(win = window)
+    v1 = view 100, 100, dynamic: true
+    v2 = view 200, 100, static:  true
+    win&.add v1
+    win&.add v2
+    [v1, v2, win, win&.root]
+  end
+
+  def test_activation()
+    v1, v2, = setup_views nil
+    w       = window
+
+    c = v1.link v2; assert_false c.active?
+    w.add    v1;    assert_false c.active?
+    w.add    v2;    assert_true  c.active?
+    w.remove v1;    assert_false c.active?
+    w.add    v1;    assert_true  c.active?
+    c = v1.link v2; assert_true  c.active?
+
+    assert_in_delta 100, c.current_distance
+  end
+
+  def test_pins()
+    v1, v2, = setup_views
+
+    c = v1.pin(10, 20).snap v2.pin(30, 40)
+    assert_equal       v1,            c.pins[0].view
+    assert_equal_point point(10, 20), c.pins[0].pos
+    assert_equal       v2,            c.pins[1].view
+    assert_equal_point point(30, 40), c.pins[1].pos
+    assert_equal       [v1, v2],      c.views
+    assert_equal       [v1, v2],      c.pins.map(&:view)
+  end
+
+  def test_resolved_positions()
+    v1, v2, = setup_views
+
+    assert_equal_point point( 25,   25), v1.pin        .snap(v2)        .pins[0].pos
+    assert_equal_point point(-75,   25), v1.pin        .snap(v2)        .pins[1].pos
+    assert_equal_point point( 10,   20), v1.pin(10, 20).snap(v2)        .pins[0].pos
+    assert_equal_point point(-90,   20), v1.pin(10, 20).snap(v2)        .pins[1].pos
+    assert_equal_point point( 130,  40), v1.pin        .snap(v2, 30, 40).pins[0].pos
+    assert_equal_point point( 30,   40), v1.pin        .snap(v2, 30, 40).pins[1].pos
+    assert_equal_point point( 50,   60), v1.pin(50, 60).snap(v2, 70, 80).pins[0].pos
+    assert_equal_point point( 70,   80), v1.pin(50, 60).snap(v2, 70, 80).pins[1].pos
+  end
+
+  def test_spring()
+    v1, v2, = setup_views
+
+    c = v1.link v2, spring: 4, damping: 0.5
+    assert_in_delta 4,                 c.spring
+    assert_in_delta 0.5,               c.damping
+
+    c.spring = nil; assert_nil         c.spring
+    c.spring = 8;   assert_in_delta 8, c.spring
+  end
+
+  def test_collide()
+    v1, v2, = setup_views
+
+    assert_false v1.snap(v2)                .collide?
+    assert_false v1.snap(v2, collide: false).collide?
+    assert_true  v1.snap(v2, collide: true) .collide?
+  end
+
+  def test_block()
+    v1, v2, = setup_views
+
+    c = v1.link v2 do
+      distance 80
+      spring   4
+    end
+    assert_equal    80, c.distance
+    assert_in_delta 4,  c.spring
+  end
+
+  def test_constraints()
+    v1, v2, = setup_views
+
+    c1 = v1.link v2
+    c2 = v1.snap v2
+    assert_equal [c1, c2], v1.constraints.to_a
+    assert_equal [c1, c2], v2.constraints.to_a
+  end
+
+  def test_remove()
+    v1, v2, _, parent = setup_views
+
+    c = v1.link v2
+    c.remove
+    assert_false     c.active?
+    assert_true      c.removed?
+    assert_equal [], v1.constraints.to_a
+    assert_equal [], v2.constraints.to_a
+
+    c.remove # idempotent
+
+    parent.remove v1
+    parent.add    v1
+    assert_false c.active? # never comes back
+
+    assert_nothing_raised do
+      c.spring   = 4
+      c.damping  = 0.5
+      c.distance = 50
+    end
+    assert_false c.active? # removed constraint is inert
+  end
+
+  def test_constrain_to_itself_error()
+    v, = setup_views
+    assert_raise(ArgumentError) {v.snap v}
+  end
+
+  def test_world_mismatch_error()
+    win             = window
+    parent1, child1 = view(0, 0, 500, 500), view(100, 100, dynamic: true)
+    parent2, child2 = view(0, 0, 500, 500), view(100, 100, dynamic: true)
+    parent1.add child1
+    parent2.add child2
+    win.add parent1
+    win.add parent2
+    child1.meter2pixel # create parent1 world
+    child2.meter2pixel # create parent2 world
+
+    assert_raise(Reflex::PhysicsError) {child1.snap child2}
+    assert_equal [], child1.constraints.to_a # rejected pins leave no trace
+    assert_equal [], child2.constraints.to_a
+  end
+
+end# TestConstraint

--- a/reflex/test/test_constraint.rb
+++ b/reflex/test/test_constraint.rb
@@ -84,6 +84,32 @@ class TestConstraint < Test::Unit::TestCase
     assert_true  v1.snap(v2, collide: true) .collide?
   end
 
+  def test_selector()
+    v1, v2, = setup_views
+
+    c = v1.link v2, name: :name1, tag: [:tag1, :tag2]
+    assert_equal 'name1',          c.name
+    assert_equal ['tag1', 'tag2'], c.tags.to_a
+    assert_true                    c.tag?(:tag1)
+    assert_true                    c.tag?('tag1')
+    assert_true                    c.tag?(:tag2)
+    assert_false                   c.tag?(:tag3)
+
+    c.name = :name2
+    assert_equal 'name2', c.name
+
+    assert_false                           c.tag?(:tag9)
+    c.add_tag                                     :tag9
+    assert_true                            c.tag?(:tag9)
+    assert_equal ['tag1', 'tag2', 'tag9'], c.tags.to_a
+    c.remove_tag                                  :tag9
+    assert_false                           c.tag?(:tag9)
+    assert_equal ['tag1', 'tag2'],         c.tags.to_a
+
+    c.clear_tags
+    assert_equal [], c.tags.to_a
+  end
+
   def test_block()
     v1, v2, = setup_views
 

--- a/reflex/test/test_link_constraint.rb
+++ b/reflex/test/test_link_constraint.rb
@@ -1,0 +1,110 @@
+require_relative 'helper'
+
+
+class TestLinkConstraint < Test::Unit::TestCase
+
+  def window()
+    Reflex::Window.new
+  end
+
+  def view(x = 0, y = 0, w = 50, h = 50, **options, &block)
+    Reflex::View.new(
+      frame: [x, y, w, h],
+      shape: Reflex::RectShape.new(density: 1),
+      **options, &block)
+  end
+
+  def point(...)
+    Reflex::Point.new(...)
+  end
+
+  def setup_views(win = window)
+    v1 = view 100, 100, dynamic: true
+    v2 = view 200, 100, static:  true
+    win&.add v1
+    win&.add v2
+    [v1, v2, win, win&.root]
+  end
+
+  def test_initial_state()
+    v1, v2, = setup_views
+
+    assert_equal v1,     v1.link(v2)              .pins[0].view
+    assert_equal v2,     v1.link(v2)              .pins[1].view
+    assert_equal 100,    v1.link(v2)              .distance
+    assert_equal 1,      v1.link(v2, distance: 1) .distance
+    assert_equal 2,      v1.link(v2, dist:     2) .distance
+    assert_nil           v1.link(v2)              .range
+    assert_equal 3..3,   v1.link(v2, range: 3)    .range
+    assert_equal 4..5,   v1.link(v2, range: 4..5) .range
+    assert_nil           v1.link(v2)              .motor
+    assert_equal 6,      v1.link(v2, motor: 6)    .motor
+    assert_nil           v1.link(v2)              .spring
+    assert_equal 7,      v1.link(v2, spring: 7)   .spring
+    assert_in_delta 0.7, v1.link(v2)              .damping
+    assert_in_delta 0.1, v1.link(v2, damping: 0.1).damping
+    assert_false         v1.link(v2)              .collide?
+    assert_true          v1.link(v2)              .active?
+    assert_false         v1.link(v2)              .removed?
+  end
+
+  def test_link_to_view()
+    v1, v2, _, root = setup_views
+    root.gravity(-900, 0)
+
+    c = v1.link v2, dist: 50
+    assert_equal v2, c.pins[1].view
+
+    60.times {root.update_world}
+    assert_equal_point point(150, 100), v1.pos
+    assert_in_delta    50,              c.current_distance, 0.01
+  end
+
+  def test_link_to_world()
+    v1, _, _, root = setup_views
+    root.gravity(-900, 0)
+
+    c = v1.pin.link [200, 125], dist: 50
+    assert_nil c.pins[1].view
+
+    60.times {root.update_world}
+    assert_equal_point point(125, 100), v1.pos
+    assert_in_delta    50,              c.current_distance, 0.01
+  end
+
+  def test_distance()
+    v1, v2, = setup_views
+
+    c = v1.link v2, dist: 80, spring: 4
+    assert_equal 80, c.distance
+    assert_equal 80, c.dist
+
+    c.dist = 90
+    assert_equal 90, c.distance
+  end
+
+  def test_range()
+    v1, v2, _, root = setup_views
+    root.gravity 0, 900
+
+    c = v1.link v2, distance: 100, range: 0..120, spring: 1, damping: 0
+    60.times {root.update_world}
+    assert_operator c.current_distance, :<=, 121
+
+    c.range = nil
+    assert_nil c.range
+
+    assert_raise(ArgumentError) {c.range = 'invalid'}
+  end
+
+  def test_motor()
+    v1, v2, = setup_views
+
+    c = v1.link v2, motor: 10
+    assert_equal 10, c.motor
+
+    c.motor = nil
+    assert_nil c.motor
+  end
+
+end# TestLinkConstraint

--- a/reflex/test/test_pin.rb
+++ b/reflex/test/test_pin.rb
@@ -1,0 +1,65 @@
+require_relative 'helper'
+
+
+class TestPin < Test::Unit::TestCase
+
+  def pin(...)
+    Reflex::Pin.new(...)
+  end
+
+  def view()
+    Reflex::View.new frame: [0, 0, 50, 50]
+  end
+
+  def point(*args)
+    Reflex::Point.new(*args)
+  end
+
+  def test_initialize()
+    v = view
+    assert_nil                pin                .view
+    assert_nil                pin                .pos
+    assert_nil                pin(         1)    .view
+    assert_equal point(1, 1), pin(         1)    .pos
+    assert_nil                pin(         2, 3) .view
+    assert_equal point(2, 3), pin(         2, 3) .pos
+    assert_equal v,           pin(v)             .view
+    assert_nil                pin(v)             .pos
+    assert_equal v,           pin(v,       4, 5) .view
+    assert_equal point(4, 5), pin(v,       4, 5) .pos
+    assert_equal v,           pin(v,      [6, 7]).view
+    assert_equal point(6, 7), pin(v,      [6, 7]).pos
+    assert_equal v,           pin(v, point(8, 9)).view
+    assert_equal point(8, 9), pin(v, point(8, 9)).pos
+  end
+
+  def test_dup()
+    v = view
+    assert_nil                pin         .dup.view
+    assert_nil                pin         .dup.pos
+    assert_nil                pin(   1, 2).dup.view
+    assert_equal point(1, 2), pin(   1, 2).dup.pos
+    assert_equal v,           pin(v, 3, 4).dup.view
+    assert_equal point(3, 4), pin(v, 3, 4).dup.pos
+  end
+
+  def test_pin()
+    v = view
+    assert_instance_of Reflex::Pin, v.pin
+
+    assert_equal v,           v.pin             .view
+    assert_nil                v.pin             .pos
+    assert_equal v,           v.pin(      1)    .view
+    assert_equal point(1, 1), v.pin(      1)    .pos
+    assert_equal v,           v.pin(      2, 3) .view
+    assert_equal point(2, 3), v.pin(      2, 3) .pos
+    assert_equal v,           v.pin(     [4, 5]).view
+    assert_equal point(4, 5), v.pin(     [4, 5]).pos
+    assert_equal v,           v.pin(point(6, 7)).view
+    assert_equal point(6, 7), v.pin(point(6, 7)).pos
+
+    assert_raise(TypeError) {v.pin view}
+    assert_raise(TypeError) {v.pin "invalid"}
+  end
+
+end# TestPin

--- a/reflex/test/test_rail_constraint.rb
+++ b/reflex/test/test_rail_constraint.rb
@@ -1,0 +1,161 @@
+require_relative 'helper'
+
+
+class TestRailConstraint < Test::Unit::TestCase
+
+  def window()
+    Reflex::Window.new
+  end
+
+  def view(x = 0, y = 0, w = 50, h = 50, **options, &block)
+    Reflex::View.new(
+      frame: [x, y, w, h],
+      shape: Reflex::RectShape.new(density: 1),
+      **options, &block)
+  end
+
+  def point(...)
+    Reflex::Point.new(...)
+  end
+
+  def setup_views(win = window)
+    v1 = view 100, 100, dynamic: true
+    v2 = view 200, 100, static:  true
+    win&.add v1
+    win&.add v2
+    [v1, v2, win, win&.root]
+  end
+
+  def test_initial_state()
+    v1, v2, = setup_views
+
+    assert_equal v1,                v1.rail(v2)              .pins[0].view
+    assert_equal v2,                v1.rail(v2)              .pins[1].view
+    assert_equal_point point(0, 1), v1.rail(v2)              .axis
+    assert_equal_point point(1, 0), v1.rail(v2, axis: [1, 0]).axis
+    assert_false                    v1.rail(v2)              .rotate?
+    assert_true                     v1.rail(v2, rotate: true).rotate?
+    assert_nil                      v1.rail(v2)              .range
+    assert_equal 2..3,              v1.rail(v2, range: 2..3) .range
+    assert_nil                      v1.rail(v2)              .motor
+    assert_equal 4,                 v1.rail(v2, motor: 4)    .motor
+    assert_nil                      v1.rail(v2)              .spring
+    assert_equal 5,                 v1.rail(v2, spring: 5)   .spring
+    assert_in_delta 0.7,            v1.rail(v2)              .damping
+    assert_in_delta 0.1,            v1.rail(v2, damping: 0.1).damping
+    assert_false                    v1.rail(v2)              .collide?
+    assert_true                     v1.rail(v2)              .active?
+    assert_false                    v1.rail(v2)              .removed?
+  end
+
+  def test_rail_to_view()
+    v1, v2, _, root = setup_views
+    root.gravity 900, 900
+
+    c = v1.rail v2, axis: [1, 0]
+    assert_equal v2, c.pins[1].view
+
+    root.update_world
+    assert_operator    v1.linear_velocity.x, :>, 0
+    assert_in_delta 0, v1.linear_velocity.y
+  end
+
+  def test_rail_to_world()
+    v1, _, _, root = setup_views
+    root.gravity 900, 900
+
+    c = v1.rail axis: [1, 0]
+    assert_nil c.pins[1].view
+
+    root.update_world
+    assert_operator    v1.linear_velocity.x, :>, 0
+    assert_in_delta 0, v1.linear_velocity.y
+  end
+
+  def test_locks_off_axis_motion()
+    v1, v2, _, root = setup_views
+
+    v1.rail v2, axis: [1, 0]
+
+    v1.linear_velocity = [100, 100]
+    3.times {root.update_world}
+    assert_operator    v1.linear_velocity.x, :>, 0
+    assert_in_delta 0, v1.linear_velocity.y
+
+    v1.angular_velocity = 90
+    3.times {root.update_world}
+    assert_in_delta 0, v1.angular_velocity
+  end
+
+  def test_axis()
+    v1, v2, _, root = setup_views
+    root.gravity 900, 900
+
+    c = v1.rail v2, axis: [1, 0]
+    assert_equal_point point(1, 0), c.axis
+
+    root.update_world
+    assert_operator    v1.linear_velocity.x, :>, 0
+    assert_in_delta 0, v1.linear_velocity.y
+
+    c.axis = [0, 1]
+    assert_equal_point point(0, 1), c.axis
+
+    root.update_world
+    assert_in_delta 0, v1.linear_velocity.x
+    assert_operator    v1.linear_velocity.y, :>, 0
+  end
+
+  def test_rotate()
+    v1, v2, _, root = setup_views
+
+    c = v1.rail v2, rotate: true, motor: 90
+    assert_true c.rotate?
+
+    root.update_world
+    assert_operator v1.angular_velocity, :>, 0
+
+    c.rotate = false
+    assert_false c.rotate?
+
+    root.update_world
+    assert_in_delta 0, v1.angular_velocity
+  end
+
+  def test_range()
+    v1, v2, _, root = setup_views
+    root.gravity 0, 900
+
+    c = v1.pin(25, 25).rail v2.pin(25, 25), axis: [0, 1], range: 100..200
+    assert_equal 100..200, c.range
+
+    60.times {root.update_world}
+    assert_equal_point point(200, 300), v1.pos
+
+    c.range = nil
+    assert_nil c.range
+
+    assert_raise(ArgumentError) {c.range = 'invalid'}
+  end
+
+  def test_motor()
+    v1, v2, _, root = setup_views
+    root.gravity(-900, 0)
+
+    c = v1.rail v2, axis: [1, 0], motor: 100
+    assert_equal 100,  c.motor
+
+    3.times {root.update_world}
+    v1_linear_vx     = v1.linear_velocity.x
+    assert_operator    v1_linear_vx, :>, 1
+    assert_in_delta 0, v1.linear_velocity.y
+
+    c.motor = nil
+    assert_nil c.motor
+
+    3.times {root.update_world}
+    assert_operator    v1.linear_velocity.x, :<, v1_linear_vx
+    assert_in_delta 0, v1.linear_velocity.y
+  end
+
+end# TestRailConstraint

--- a/reflex/test/test_snap_constraint.rb
+++ b/reflex/test/test_snap_constraint.rb
@@ -1,0 +1,116 @@
+require_relative 'helper'
+
+
+class TestSnapConstraint < Test::Unit::TestCase
+
+  def window()
+    Reflex::Window.new
+  end
+
+  def view(x = 0, y = 0, w = 50, h = 50, **options, &block)
+    Reflex::View.new(
+      frame: [x, y, w, h],
+      shape: Reflex::RectShape.new(density: 1),
+      **options, &block)
+  end
+
+  def point(...)
+    Reflex::Point.new(...)
+  end
+
+  def setup_views(win = window)
+    v1 = view 100, 100, dynamic: true
+    v2 = view 200, 100, static:  true
+    win&.add v1
+    win&.add v2
+    [v1, v2, win, win&.root]
+  end
+
+  def test_initial_state()
+    v1, v2, = setup_views
+
+    assert_equal v1,     v1.snap(v2)              .pins[0].view
+    assert_equal v2,     v1.snap(v2)              .pins[1].view
+    assert_nil           v1.snap(v2)              .angle
+    assert_equal 1..1,   v1.snap(v2, angle: 1)    .angle
+    assert_equal 2..3,   v1.snap(v2, angle: 2..3) .angle
+    assert_nil           v1.snap(v2)              .motor
+    assert_equal 4,      v1.snap(v2, motor: 4)    .motor
+    assert_nil           v1.snap(v2)              .spring
+    assert_equal 5,      v1.snap(v2, spring: 5)   .spring
+    assert_in_delta 0.7, v1.snap(v2)              .damping
+    assert_in_delta 0.1, v1.snap(v2, damping: 0.1).damping
+    assert_false         v1.snap(v2)              .collide?
+    assert_true          v1.snap(v2)              .active?
+    assert_false         v1.snap(v2)              .removed?
+  end
+
+  def test_snap_keeps_positions()
+    v1, v2, _, root = setup_views
+    v1.angle = 45
+
+    v1.snap v2 # nothing moves
+
+    10.times {root.update_world}
+    assert_equal_point point(0), v1.linear_velocity
+  end
+
+  def test_snap_pulls_together()
+    v1, v2, _, root = setup_views
+
+    v1.pin(25, 25).snap v2.pin(25, 25), angle: 0, spring: 4
+
+    root.update_world
+    assert_operator v1.linear_velocity.x, :>, 0
+  end
+
+  def test_snap_to_world()
+    v1, _, _, root = setup_views
+    root.gravity 0, 900
+
+    c = v1.snap
+    assert_nil c.pins[1].view
+
+    60.times {root.update_world}
+    assert_in_delta 100, v1.frame.y, 0.01 # hangs against gravity
+  end
+
+  def test_weld_fixes_angle()
+    v1, v2, _, root = setup_views
+
+    v1.snap v2, angle: 0 # welds and fixes the angle
+    v1.angular_velocity = 90
+
+    10.times {root.update_world}
+    assert_in_delta 0, v1.angular_velocity
+  end
+
+  def test_angle()
+    v1, v2, = setup_views
+
+    c = v1.snap v2, angle: -30..90
+    assert_equal(-30..90, c.angle)
+
+    c.angle = 0
+    assert_equal 0..0, c.angle
+
+    c.angle = nil
+    assert_nil c.angle
+
+    assert_raise(ArgumentError) {c.angle = 'invalid'}
+  end
+
+  def test_motor()
+    v1, v2, _, root = setup_views
+
+    c = v1.snap v2, motor: 90
+    assert_equal 90, c.motor
+
+    3.times {root.update_world}
+    assert_in_delta 90, v1.angular_velocity
+
+    c.motor = nil
+    assert_nil c.motor
+  end
+
+end# TestSnapConstraint

--- a/reflex/test/test_view.rb
+++ b/reflex/test/test_view.rb
@@ -145,10 +145,11 @@ class TestView < Test::Unit::TestCase
   end
 
   def test_find_styles()
-    v, s = view, style(tag: :T1)
+    v, s = view, style(name: :N1, tag: :T1)
     s.add_tag :T2
     v.add_style s
 
+    assert_includes v.find_styles(:N1),                       s
     assert_includes v.find_styles(selector tag:   :T1),       s
     assert_includes v.find_styles(selector tags: [:T1, :T2]), s
     assert_empty    v.find_styles(selector tags: [:T1, :X])
@@ -228,14 +229,34 @@ class TestView < Test::Unit::TestCase
   end
 
   def test_find_shapes()
-    v, s = view, shape(tag: :T1)
+    v, s = view, shape(name: :N1, tag: :T1)
     s.add_tag :T2
     v.add_shape s
 
+    assert_includes v.find_shapes(:N1),                       s
     assert_includes v.find_shapes(selector tag:   :T1),       s
     assert_includes v.find_shapes(selector tags: [:T1, :T2]), s
     assert_empty    v.find_shapes(selector tags: [:T1, :X])
     assert_empty    v.find_shapes(selector tag:   :X)
+  end
+
+  def test_find_constraints()
+    win = window
+    v1 = view frame: [100, 100, 50, 50], shape: shape(density: 1), dynamic: true
+    v2 = view frame: [200, 100, 50, 50], shape: shape(density: 1), static:  true
+    win.add v1
+    win.add v2
+
+    c = v1.link v2, name: :N1, tag: :T1
+    c.add_tag :T2
+
+    [v1, v2].each do |v|
+      assert_includes v.find_constraints(:N1),                       c
+      assert_includes v.find_constraints(selector tag:   :T1),       c
+      assert_includes v.find_constraints(selector tags: [:T1, :T2]), c
+      assert_empty    v.find_constraints(selector tags: [:T2, :X])
+      assert_empty    v.find_constraints(selector tags: [:X])
+    end
   end
 
   def test_name()


### PR DESCRIPTION
Adds a constraint mechanism for Views, wrapping Box2D v3 joints.

## Overview

Constraints are created through a **pin algebra**:

```ruby
Pin(view, x, y).snap/link/rail/chase(target)
```

A pin without a view anchors to the world (ground), backed by a fixture-less
ground body per world. A constraint is a persistent *declaration* while the
b2 joint is a disposable cache: activated lazily once both views are attached
to the same world, recreated on re-attach, and severed permanently only by
`remove()`.

## Four families

| Family | Box2D joint | Role |
|--------|-------------|------|
| `SnapConstraint`  | revolute / weld   | make two points coincide |
| `LinkConstraint`  | distance          | keep two pins apart |
| `RailConstraint`  | prismatic / wheel | slide along an axis |
| `ChaseConstraint` | mouse             | track a target pin every step |

## What's included

- **C++ core** — constraint creation, lazy activation, and per-world boundary
  management.
- **Ruby bindings** — `Pin.new` routes through the C++ Pin constructor via
  `value_to<Pin>`, so a single argument-parsing path handles
  view / point / [view, x, y] / nil for every verb. Constraints can only be
  created through `view.pin`; direct `new` is disallowed.
- **Selectable** — Constraint carries a selector (name / tags) like the other
  things a view collects (children, shapes, styles), so a joint can be
  identified in a crowded rig (a ragdoll knee, a drawer's rail) and looked up
  with `View#find_constraints`.
- **Tests** — each family plus pin, selector, and error cases (e.g. world
  mismatch).
- **Sample** — `samples/constraint.rb` shows all four families in one scene
  (pendulum, motored arm, spring chain, a car driving over bumpy ground, and a
  pointer chaser with drag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DM4Zq1TLdHhxvG9tsR5bUL