### PR TITLE
rays: Default to BGRA color space on Windows

### DIFF
--- a/rays/ext/rays/bitmap.cpp
+++ b/rays/ext/rays/bitmap.cpp
@@ -29,7 +29,7 @@ RUCY_DEFN(initialize)
 
 	*THIS = Rays::Bitmap(
 		to<int>(argv[0]), to<int>(argv[1]),
-		argc >= 3 ? to<Rays::ColorSpace>(argv[2]) : Rays::RGBA);
+		argc >= 3 ? to<Rays::ColorSpace>(argv[2]) : Rays::DEFAULT_COLORSPACE);
 
 	return self;
 }

--- a/rays/ext/rays/image.cpp
+++ b/rays/ext/rays/image.cpp
@@ -42,7 +42,7 @@ RUCY_DEF3(initialize, args, pixel_density, smooth)
 	{
 		int width  = to<int>(args[0]);
 		int height = to<int>(args[1]);
-		auto cs    = (argc >= 3) ? to<Rays::ColorSpace>(args[2]) : Rays::RGBA;
+		auto cs    = (argc >= 3) ? to<Rays::ColorSpace>(args[2]) : Rays::DEFAULT_COLORSPACE;
 		*THIS = Rays::Image(width, height, cs, pd, smooth);
 	}
 

--- a/rays/include/rays/bitmap.h
+++ b/rays/include/rays/bitmap.h
@@ -24,7 +24,7 @@ namespace Rays
 			Bitmap ();
 
 			Bitmap (
-				int width, int height, const ColorSpace& cs = RGBA,
+				int width, int height, const ColorSpace& cs = DEFAULT_COLORSPACE,
 				const void* pixels = NULL);
 
 			~Bitmap ();

--- a/rays/include/rays/color_space.h
+++ b/rays/include/rays/color_space.h
@@ -40,7 +40,11 @@ namespace Rays
 
 		BGRA  = BGRA_8888, BGRX = BGRX_8888, ABGR = ABGR_8888, XBGR = XBGR_8888,
 
-		DEFAULT_COLOR_SPACE = RGBA
+#ifdef WIN32
+		DEFAULT_COLORSPACE = BGRA,
+#else
+		DEFAULT_COLORSPACE = RGBA,
+#endif
 
 	};// ColorSpaceType
 

--- a/rays/include/rays/color_space.h
+++ b/rays/include/rays/color_space.h
@@ -14,7 +14,7 @@ namespace Rays
 	enum ColorSpaceType
 	{
 
-		COLORSPACE_UNKNOWN = 0,
+		COLORSPACE_NONE = 0,
 
 		 GRAY_8,  GRAY_16,  GRAY_24,  GRAY_32,  GRAY_float,
 

--- a/rays/include/rays/image.h
+++ b/rays/include/rays/image.h
@@ -26,7 +26,7 @@ namespace Rays
 			Image ();
 
 			Image (
-				int width, int height, const ColorSpace& cs = DEFAULT_COLOR_SPACE,
+				int width, int height, const ColorSpace& cs = DEFAULT_COLORSPACE,
 				float pixel_density = 1, bool smooth = false);
 
 			Image (

--- a/rays/src/color_space.cpp
+++ b/rays/src/color_space.cpp
@@ -26,7 +26,7 @@ namespace Rays
 
 
 	ColorSpace::ColorSpace ()
-	:	type_(COLORSPACE_UNKNOWN), premult(false)
+	:	type_(COLORSPACE_NONE), premult(false)
 	{
 	}
 
@@ -46,7 +46,7 @@ namespace Rays
 	{
 		static const int BPPS[] =
 		{
-			0,                 // UNKNOWN
+			0,                 // NONE
 			8, 16, 24, 32, 32, // GRAY
 			8, 16, 24, 32, 32, // ALPHA
 			8, 8, 8, 8, 8,     // RGB(A),
@@ -54,7 +54,7 @@ namespace Rays
 			32, 32, 32,        // RGB(A) float
 			32, 32, 32,        // BGR(A) float
 		};
-		if (type_ < 0 || COLORSPACE_MAX <= type_) return BPPS[COLORSPACE_UNKNOWN];
+		if (type_ < 0 || COLORSPACE_MAX <= type_) return BPPS[COLORSPACE_NONE];
 		return BPPS[type_];
 	}
 
@@ -69,7 +69,7 @@ namespace Rays
 	{
 		static const int BPPS[] =
 		{
-			0,                     // UNKNOWN
+			0,                     // NONE
 			8,  16,  24,  32,  32, // GRAY
 			8,  16,  24,  32,  32, // ALPHA
 			24, 32,  32,  32,  32, // RGB(A)
@@ -77,7 +77,7 @@ namespace Rays
 			96, 128, 128,          // RGB(A) float
 			96, 128, 128,          // BGR(A) float
 		};
-		if (type_ < 0 || COLORSPACE_MAX <= type_) return BPPS[COLORSPACE_UNKNOWN];
+		if (type_ < 0 || COLORSPACE_MAX <= type_) return BPPS[COLORSPACE_NONE];
 		return BPPS[type_];
 	}
 

--- a/rays/src/ios/bitmap.mm
+++ b/rays/src/ios/bitmap.mm
@@ -120,7 +120,7 @@ namespace Rays
 			if (pixels) delete [] (uchar*) pixels;
 
 			width = height = 0;
-			color_space = COLORSPACE_UNKNOWN;
+			color_space = COLORSPACE_NONE;
 			pixels      = NULL;
 			context     = NULL;
 			modified    = false;
@@ -323,8 +323,8 @@ namespace Rays
 	{
 		if (!*this)
 		{
-			static const ColorSpace UNKNOWN = COLORSPACE_UNKNOWN;
-			return UNKNOWN;
+			static const ColorSpace NONE = COLORSPACE_NONE;
+			return NONE;
 		}
 		return self->color_space;
 	}

--- a/rays/src/opengl/bitmap.cpp
+++ b/rays/src/opengl/bitmap.cpp
@@ -23,7 +23,7 @@ namespace Rays
 			&bmp, tex.width(), tex.height(), tex.color_space(), NULL, false);
 
 		GLenum format, type;
-		ColorSpace_get_gl_format_and_type(&format, &type, tex.color_space());
+		ColorSpace_get_gl_format_and_type(NULL, &format, &type, tex.color_space());
 
 		FrameBuffer fb(tex);
 		FrameBufferBinder binder(fb.id());

--- a/rays/src/opengl/color_space.cpp
+++ b/rays/src/opengl/color_space.cpp
@@ -10,13 +10,22 @@ namespace Rays
 
 	void
 	ColorSpace_get_gl_format_and_type (
-		GLenum* format, GLenum* type, const ColorSpace& cs)
+		GLenum* internalformat, GLenum* format, GLenum* type, const ColorSpace& cs)
 	{
-		if (!format && !type)
+		if (!internalformat && !format && !type)
 			argument_error(__FILE__, __LINE__);
 
 		if (!cs)
 			invalid_state_error(__FILE__, __LINE__);
+
+		if (internalformat)
+		{
+			if (cs.is_rgb() || cs.is_bgr()) *internalformat = cs.has_alpha() ? GL_RGBA  : GL_RGB;
+			else if (cs.is_gray())          *internalformat = GL_LUMINANCE;
+			else if (cs.is_alpha())         *internalformat = GL_ALPHA;
+			else
+				rays_error(__FILE__, __LINE__, "invalid color space.");
+		}
 
 		if (format)
 		{

--- a/rays/src/opengl/color_space.h
+++ b/rays/src/opengl/color_space.h
@@ -13,7 +13,7 @@ namespace Rays
 
 
 	void ColorSpace_get_gl_format_and_type (
-		GLenum* format, GLenum* type, const ColorSpace& cs);
+		GLenum* internalformat, GLenum* format, GLenum* type, const ColorSpace& cs);
 
 
 }// Rays

--- a/rays/src/opengl/texture.cpp
+++ b/rays/src/opengl/texture.cpp
@@ -194,14 +194,14 @@ namespace Rays
 		glTexParameteri(
 			GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, smooth ? GL_LINEAR : GL_NEAREST);
 
-		GLenum format, type;
-		ColorSpace_get_gl_format_and_type(&format, &type, cs);
+		GLenum internalformat, format, type;
+		ColorSpace_get_gl_format_and_type(&internalformat, &format, &type, cs);
 
 		if (npot)
 		{
 			// create non-power-of-two texture
 			glTexImage2D(
-				GL_TEXTURE_2D, 0, format, width, height, 0, format, type,
+				GL_TEXTURE_2D, 0, internalformat, width, height, 0, format, type,
 				bitmap ? bitmap->pixels() : NULL);
 			npot = OpenGL_has_error();
 		}
@@ -274,7 +274,7 @@ namespace Rays
 			argument_error(__FILE__, __LINE__, "the height of bitmap does not match");
 
 		GLenum format, type;
-		ColorSpace_get_gl_format_and_type(&format, &type, bitmap.color_space());
+		ColorSpace_get_gl_format_and_type(NULL, &format, &type, bitmap.color_space());
 
 		glBindTexture(GL_TEXTURE_2D, self->id);
 		glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w, h, format, type, bitmap.pixels());

--- a/rays/src/opengl/texture.cpp
+++ b/rays/src/opengl/texture.cpp
@@ -42,7 +42,7 @@ namespace Rays
 			height      =
 			width_pow2  =
 			height_pow2 = 0;
-			color_space = COLORSPACE_UNKNOWN;
+			color_space = COLORSPACE_NONE;
 			smooth      = false;
 			modified    = false;
 		}

--- a/rays/src/osx/bitmap.mm
+++ b/rays/src/osx/bitmap.mm
@@ -119,7 +119,7 @@ namespace Rays
 			if (pixels) delete [] (uchar*) pixels;
 
 			width = height = 0;
-			color_space = COLORSPACE_UNKNOWN;
+			color_space = COLORSPACE_NONE;
 			pixels      = NULL;
 			context     = NULL;
 			modified    = false;
@@ -322,8 +322,8 @@ namespace Rays
 	{
 		if (!*this)
 		{
-			static const ColorSpace UNKNOWN = COLORSPACE_UNKNOWN;
-			return UNKNOWN;
+			static const ColorSpace NONE = COLORSPACE_NONE;
+			return NONE;
 		}
 		return self->color_space;
 	}

--- a/rays/src/sdl/bitmap.cpp
+++ b/rays/src/sdl/bitmap.cpp
@@ -9,6 +9,8 @@
 #include <SDL.h>
 #include <xot/util.h>
 #include "rays/exception.h"
+#include "rays/image.h"
+#include "rays/painter.h"
 #include "../font.h"
 #include "../texture.h"
 
@@ -142,8 +144,8 @@ namespace Rays
 		return strrchr(path, '.');
 	}
 
-	void
-	Bitmap_save (const Bitmap& bmp, const char* path)
+	static void
+	save_bitmap (const Bitmap& bitmap, const char* path)
 	{
 		const char* extension = get_ext(path);
 		if (!extension)
@@ -152,14 +154,14 @@ namespace Rays
 				__FILE__, __LINE__, "invalid image file extension: '%s'", path);
 		}
 
-		const auto& cs = bmp.color_space();
-		int w          = bmp.width();
-		int h          = bmp.height();
+		const auto& cs = bitmap.color_space();
+		int w          = bitmap.width();
+		int h          = bitmap.height();
 		int pitch      = w * cs.Bpp();
 
 		std::unique_ptr<uchar[]> pixels(new uchar[h * pitch]);
 		for (int y = 0; y < h; ++y)
-			memcpy(pixels.get() + pitch * y, bmp.at<uchar>(0, y), pitch);
+			memcpy(pixels.get() + pitch * y, bitmap.at<uchar>(0, y), pitch);
 
 		String ext = extension;
 		ext.downcase();
@@ -178,6 +180,23 @@ namespace Rays
 
 		if (!ret)
 			rays_error(__FILE__, __LINE__, "failed to save: '%s'", path);
+	}
+
+	void
+	Bitmap_save (const Bitmap& bitmap, const char* path)
+	{
+		Bitmap bmp    = bitmap;
+		ColorSpace cs = bmp.color_space();
+		if (!cs.is_rgb() || (cs.has_alpha() && !cs.is_alpha_last()))
+		{
+			Image img(bmp.width(), bmp.height(), cs.has_alpha() ? RGBA : RGB);
+			Painter p = img.painter();
+			p.begin();
+			p.image(Image(bmp));
+			p.end();
+			bmp = img.bitmap();
+		}
+		save_bitmap(bmp, path);
 	}
 
 	Bitmap

--- a/rays/src/sdl/bitmap.cpp
+++ b/rays/src/sdl/bitmap.cpp
@@ -41,7 +41,7 @@ namespace Rays
 			if (surface) SDL_FreeSurface(surface);
 
 			surface     = NULL;
-			color_space = COLORSPACE_UNKNOWN;
+			color_space = COLORSPACE_NONE;
 			modified    = false;
 		}
 
@@ -252,8 +252,8 @@ namespace Rays
 	{
 		if (!*this)
 		{
-			static const ColorSpace UNKNOWN = COLORSPACE_UNKNOWN;
-			return UNKNOWN;
+			static const ColorSpace NONE = COLORSPACE_NONE;
+			return NONE;
 		}
 		return self->color_space;
 	}

--- a/rays/src/texture.h
+++ b/rays/src/texture.h
@@ -26,7 +26,7 @@ namespace Rays
 			Texture ();
 
 			Texture (
-				int width, int height, const ColorSpace& cs = RGBA,
+				int width, int height, const ColorSpace& cs = DEFAULT_COLORSPACE,
 				bool smooth = false);
 
 			Texture (const Bitmap& bitmap, bool smooth = false);

--- a/rays/src/win32/bitmap.cpp
+++ b/rays/src/win32/bitmap.cpp
@@ -7,6 +7,8 @@
 #include <stb_image_write.h>
 
 #include "rays/exception.h"
+#include "rays/image.h"
+#include "rays/painter.h"
 #include "../font.h"
 #include "../texture.h"
 #include "gdi.h"
@@ -147,42 +149,59 @@ namespace Rays
 		return strrchr(path, '.');
 	}
 
-	void
-	Bitmap_save (const Bitmap& bmp, const char* path)
+	static void
+	save_bitmap (const Bitmap& bitmap, const char* path)
 	{
-		const char* ext = get_ext(path);
-		if (!ext)
+		const char* extension = get_ext(path);
+		if (!extension)
 		{
 			argument_error(
 				__FILE__, __LINE__, "invalid image file extension: '%s'", path);
 		}
 
-		const auto& cs = bmp.color_space();
-		size_t w       = bmp.width();
-		size_t h       = bmp.height();
+		const auto& cs = bitmap.color_space();
+		size_t w       = bitmap.width();
+		size_t h       = bitmap.height();
 		size_t pitch   = w * cs.Bpp();
 
 		std::unique_ptr<uchar[]> pixels(new uchar[h * pitch]);
 		for (size_t y = 0; y < h; ++y)
-			memcpy(pixels.get() + pitch * y, bmp.at<uchar>(0, y), pitch);
+			memcpy(pixels.get() + pitch * y, bitmap.at<uchar>(0, y), pitch);
+
+		String ext = extension;
+		ext.downcase();
 
 		int ret = 0;
-		if (stricmp(ext, ".bmp") == 0)
+		if      (ext == ".bmp")
 			ret = stbi_write_bmp(path, w, h, cs.Bpp(), pixels.get());
-		else
-		if (stricmp(ext, ".png") == 0)
+		else if (ext == ".png")
 			ret = stbi_write_png(path, w, h, cs.Bpp(), pixels.get(), 0);
-		else
-		if (stricmp(ext, ".jpg") == 0 || stricmp(ext, ".jpeg") == 0)
+		else if (ext == ".jpg" || ext == ".jpeg")
 			ret = stbi_write_jpg(path, w, h, cs.Bpp(), pixels.get(), 90);
-		else
-		if (stricmp(ext, ".tga") == 0)
+		else if (ext == ".tga")
 			ret = stbi_write_tga(path, w, h, cs.Bpp(), pixels.get());
 		else
 			argument_error(__FILE__, __LINE__, "unknown image file type");
 
 		if (!ret)
 			rays_error(__FILE__, __LINE__, "failed to save: '%s'", path);
+	}
+
+	void
+	Bitmap_save (const Bitmap& bitmap, const char* path)
+	{
+		Bitmap bmp    = bitmap;
+		ColorSpace cs = bmp.color_space();
+		if (!cs.is_rgb() || (cs.has_alpha() && !cs.is_alpha_last()))
+		{
+			Image img(bmp.width(), bmp.height(), cs.has_alpha() ? RGBA : RGB);
+			Painter p = img.painter();
+			p.begin();
+			p.image(Image(bmp));
+			p.end();
+			bmp = img.bitmap();
+		}
+		save_bitmap(bmp, path);
 	}
 
 	Bitmap

--- a/rays/src/win32/bitmap.cpp
+++ b/rays/src/win32/bitmap.cpp
@@ -44,7 +44,7 @@ namespace Rays
 			if (memdc) memdc = Win32::MemoryDC();
 
 			width = height = pitch = 0;
-			color_space = COLORSPACE_UNKNOWN;
+			color_space = COLORSPACE_NONE;
 			pixels      = NULL;
 			modified    = false;
 		}
@@ -257,8 +257,8 @@ namespace Rays
 	{
 		if (!*this)
 		{
-			static const ColorSpace UNKNOWN = COLORSPACE_UNKNOWN;
-			return UNKNOWN;
+			static const ColorSpace NONE = COLORSPACE_NONE;
+			return NONE;
 		}
 		return self->color_space;
 	}


### PR DESCRIPTION
## Summary

Make BGRA the default color space on Windows so rays' pixel data matches the platform's native order. Windows' graphics stack — GDI DIBs and the GPU — is natively BGRA, so RGBA data pays a byte-swap somewhere along texture upload, `glReadPixels`, or GDI interop. Using BGRA on Windows keeps the whole path conversion-free.

This surfaced from reflex's menu icons showing swapped R/B on Windows: the root cause was that `Image.bitmap()` returned RGBA while GDI expects BGRA. Rather than swap at the boundary, rays now uses BGRA natively on Windows and the mismatch disappears.

## Changes

- **Rename `COLORSPACE_UNKNOWN` → `COLORSPACE_NONE`** — the zero value is the absent/unset sentinel (default-constructed, makes `operator bool` return false), not an "unknown" color space.
- **`DEFAULT_COLORSPACE = BGRA` on Windows** (RGBA elsewhere); Image/Bitmap/Texture defaults follow it. The OpenGL layer already maps color_space → GL format, so `glTexImage2D`/`glReadPixels` pick `GL_BGRA` automatically.
- **Split internalformat from format** in `glTexImage2D` — `GL_BGRA` is only valid as an external format, not an internal one, so `ColorSpace_get_gl_format_and_type` now yields a separate order-independent internalformat (`GL_RGBA`/`GL_RGB`) while `format` carries the byte order.
- **Convert BGR bitmaps to RGB(A) before `stbi_write`** on win32/sdl (STB expects RGBA order). osx/ios save via NSImage/UIImage, not STB, so they are left untouched.

Other platforms keep RGBA, so this is a no-op for them.

## Testing

`rake test` passes on both **macOS** (RGBA path) and **Windows** (BGRA path), including `test_save_load` which verifies the save → load color round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)